### PR TITLE
Add support for user configuration

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,6 +26,7 @@ executable(
     'src/mode_tile.c',
     'src/mode_bisect.c',
     'src/utils.c',
+    'src/config.c',
     protos_src,
   ],
   dependencies: [

--- a/src/config.c
+++ b/src/config.c
@@ -1,0 +1,368 @@
+#include "config.h"
+
+#include "log.h"
+#include "state.h"
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * `field_color_parse` parses color field values, e.g.:
+ *  - 6-digit hex color code (RRGGBB): `#123456`, `123456`
+ *  - 8-digit hex color code (RRGGBBAA): `#12345678`, `12345678`
+ *  - 3-digit hex color code (RGB): `#123`, `123`
+ *  - 4-digit hex color code (RGBA): `#1234`, `1234`
+ */
+static int parse_color(void *dest, char *value) {
+    if (value[0] == '#') {
+        value++;
+    }
+
+    char digits[8];
+    int  len = 0;
+    for (int i = 0; value[i] != '\0'; i++) {
+        if (++len > 8) {
+            return 1;
+        }
+
+        char c = value[i];
+        if (c >= '0' && c <= '9') {
+            digits[i] = c - '0';
+            continue;
+        }
+
+        c |= 1 << 5; // Makes the character lower case.
+        if (c >= 'a' && c <= 'f') {
+            digits[i] = c - 'a' + 10;
+            continue;
+        }
+
+        return 2;
+    }
+
+    switch (len) {
+    case 8:;
+        *((uint32_t *)dest) = digits[7] | digits[6] << 4 |
+                              digits[5] << (4 * 2) | digits[4] << (4 * 3) |
+                              digits[3] << (4 * 4) | digits[2] << (4 * 5) |
+                              digits[1] << (4 * 6) | digits[0] << (4 * 7);
+        break;
+
+    case 6:
+        *((uint32_t *)dest) = 0xff | digits[5] << (4 * 2) |
+                              digits[4] << (4 * 3) | digits[3] << (4 * 4) |
+                              digits[2] << (4 * 5) | digits[1] << (4 * 6) |
+                              digits[0] << (4 * 7);
+        break;
+
+    case 4:
+        *((uint32_t *)dest) = digits[3] | digits[3] << 4 |
+                              digits[2] << (4 * 2) | digits[2] << (4 * 3) |
+                              digits[1] << (4 * 4) | digits[1] << (4 * 5) |
+                              digits[0] << (4 * 6) | digits[0] << (4 * 7);
+        break;
+
+    case 3:
+        *((uint32_t *)dest) = 0xff | digits[2] << (4 * 2) |
+                              digits[2] << (4 * 3) | digits[1] << (4 * 4) |
+                              digits[1] << (4 * 5) | digits[0] << (4 * 6) |
+                              digits[0] << (4 * 7);
+        break;
+
+    default:
+        return 4;
+    }
+
+    return 0;
+}
+
+static int parse_double(void *dest, char *value) {
+    *((double *)dest) = atof(value);
+    // TODO: handle errors better.
+    return 0;
+}
+
+static int parse_home_row_keys(void *dest, char *value) {
+    char ***home_row_keys_ptr = dest;
+
+    if (value[0] == '\0') {
+        *home_row_keys_ptr = NULL;
+        return 0;
+    }
+
+#define ASSERT_FOLLOW_UP_BYTE(c)           \
+    if ((*c & 0b11000000) != 0b10000000) { \
+        LOG_ERR("Encoding error.");        \
+        goto err;                          \
+    }
+
+    char  *b    = malloc(HOME_ROW_LEN_WITH_BTN * 5);
+    char **keys = malloc(HOME_ROW_LEN_WITH_BTN * sizeof(char *));
+
+    char *c = value;
+
+    for (int i = 0; i < HOME_ROW_LEN_WITH_BTN; i++) {
+        if (*c == 0) {
+            LOG_ERR("Could not parse home row keys. Not enough characters.");
+            goto err;
+        }
+
+        if ((*c & 0b10000000) == 0) {
+            b[i * 5]     = *c++;
+            b[i * 5 + 1] = 0;
+        } else if ((*c & 0b11100000) == 0b11000000) {
+            b[i * 5] = *c++;
+            ASSERT_FOLLOW_UP_BYTE(c);
+            b[i * 5 + 1] = *c++;
+            b[i * 5 + 2] = 0;
+        } else if ((*c & 0b11110000) == 0b11100000) {
+            b[i * 5] = *c++;
+            ASSERT_FOLLOW_UP_BYTE(c);
+            b[i * 5 + 1] = *c++;
+            ASSERT_FOLLOW_UP_BYTE(c);
+            b[i * 5 + 2] = *c++;
+            b[i * 5 + 3] = 0;
+        } else if ((*c & 0b11111000) == 0b11110000) {
+            b[i * 5] = *c++;
+            ASSERT_FOLLOW_UP_BYTE(c);
+            b[i * 5 + 1] = *c++;
+            ASSERT_FOLLOW_UP_BYTE(c);
+            b[i * 5 + 2] = *c++;
+            ASSERT_FOLLOW_UP_BYTE(c);
+            b[i * 5 + 3] = *c++;
+            b[i * 5 + 4] = 0;
+        }
+
+        keys[i] = &b[i * 5];
+    }
+
+    if (*c != '\0') {
+        LOG_ERR("Too many characters.");
+        goto err;
+    }
+
+    *home_row_keys_ptr = keys;
+
+    return 0;
+
+err:
+    free(b);
+    free(keys);
+    return 1;
+}
+
+static void free_home_row_keys(void *field_value) {
+    char ***home_row_keys_ptr = field_value;
+    if (*home_row_keys_ptr == NULL) {
+        return;
+    }
+
+    free(**home_row_keys_ptr);
+    free(*home_row_keys_ptr);
+
+    *home_row_keys_ptr = NULL;
+}
+
+struct field_def {
+    char  *name;
+    size_t offset;
+    char  *default_value;
+    int (*parse)(void *dest, char *value);
+    void (*free)(void *value);
+};
+
+struct section_def {
+    char              *name;
+    size_t             offset;
+    struct field_def **fields;
+};
+
+#define SECTION(name, ...)                                             \
+    (struct section_def) {                                             \
+        #name, offsetof(struct config, name), (struct field_def *[]) { \
+            __VA_ARGS__, NULL                                          \
+        }                                                              \
+    }
+
+#define FIELD(type, name, default_value, parse, free)           \
+    (struct field_def[]) {                                      \
+        #name, offsetof(type, name), default_value, parse, free \
+    }
+
+#define G_FIELD(name, default_value, parse, free) \
+    FIELD(struct general_config, name, default_value, parse, free)
+#define MT_FIELD(name, default_value, parse, free) \
+    FIELD(struct mode_tile_config, name, default_value, parse, free)
+#define MB_FIELD(name, default_value, parse, free) \
+    FIELD(struct mode_bisect_config, name, default_value, parse, free)
+
+static void noop() {}
+
+#pragma GCC diagnostic    push
+#pragma GCC diagnostic    ignored "-Wmissing-braces"
+static struct section_def section_defs[] = {
+    SECTION(
+        general,
+        G_FIELD(home_row_keys, "", parse_home_row_keys, free_home_row_keys)
+    ),
+    SECTION(
+        mode_tile, MT_FIELD(label_color, "#fffd", parse_color, noop),
+        MT_FIELD(label_select_color, "#fd0d", parse_color, noop),
+        MT_FIELD(unselectable_bg_color, "#2226", parse_color, noop),
+        MT_FIELD(selectable_bg_color, "#0304", parse_color, noop),
+        MT_FIELD(selectable_border_color, "#040c", parse_color, noop)
+    ),
+    SECTION(
+        mode_bisect, MB_FIELD(label_color, "#fffd", parse_color, noop),
+        // TODO: we should set minimums for numbers.
+        MB_FIELD(label_font_size, "20", parse_double, noop),
+        MB_FIELD(label_padding, "12", parse_double, noop),
+        MB_FIELD(pointer_size, "20", parse_double, noop),
+        MB_FIELD(pointer_color, "#e22d", parse_color, noop),
+        MB_FIELD(unselectable_bg_color, "#2226", parse_color, noop),
+        MB_FIELD(even_area_bg_color, "#0304", parse_color, noop),
+        MB_FIELD(even_area_border_color, "#0408", parse_color, noop),
+        MB_FIELD(odd_area_bg_color, "#0034", parse_color, noop),
+        MB_FIELD(odd_area_border_color, "#0048", parse_color, noop),
+        MB_FIELD(history_border_color, "#3339", parse_color, noop)
+    ),
+};
+#pragma GCC diagnostic pop
+
+void config_loader_init(struct config_loader *loader, struct config *config) {
+    loader->config           = config;
+    loader->curr_section_def = &section_defs[0];
+}
+
+int config_loader_enter_section(struct config_loader *loader, char *section) {
+    for (int i = 0; i < sizeof(section_defs) / sizeof(section_defs[0]); i++) {
+        struct section_def *section_def = &section_defs[i];
+
+        if (strcmp(section, section_def->name) == 0) {
+            loader->curr_section_def = section_def;
+            return 0;
+        }
+    }
+
+    LOG_ERR("Configuration section `%s` does not exist.", section);
+    return 1;
+}
+
+int config_loader_load_field(
+    struct config_loader *loader, char *name, char *value
+) {
+    struct section_def *section_def = loader->curr_section_def;
+
+    for (struct field_def **field_defs = section_def->fields;
+         *field_defs != NULL; field_defs++) {
+        struct field_def *field_def = *field_defs;
+
+        if (strcmp(name, field_def->name) == 0) {
+            void *dest = ((void *)loader->config) + section_def->offset +
+                         field_def->offset;
+            field_def->free(dest);
+            int err = field_def->parse(dest, value);
+            if (err != 0) {
+                LOG_ERR("Invalid value for %s.%s.", section_def->name, name);
+                return 2;
+            }
+
+            return 0;
+        }
+    }
+
+    LOG_ERR(
+        "Configuration option `%s.%s` does not exist.", section_def->name, name
+    );
+    return 1;
+}
+
+int config_loader_load_cli_param(struct config_loader *loader, char *value) {
+    // `buf` will hold a copy of the section and field name as
+    // `section\0field\0`.
+    char buf[strlen(value)];
+
+    // `bc` holds the current position in `buf`. Each time we write to `buf`
+    // this pointer is incremented.
+    char *bc = buf;
+
+    // `c` holds the current position in `value`.
+    char *c = value;
+
+    char *section = buf;
+    while (*c != '\0' && *c != '.' && *c != '=') {
+        *(bc++) = *(c++);
+    }
+
+    if (*c != '.') {
+        LOG_ERR("Invalid configuration parameter `%s`.", value);
+        return 1;
+    }
+
+    *(bc++) = '\0';
+    c++;
+
+    char *field_name = bc;
+    while (*c != '\0' && *c != '=') {
+        *(bc++) = *(c++);
+    }
+
+    if (*c != '=') {
+        LOG_ERR("Invalid configuration parameter `%s`.", value);
+        return 1;
+    }
+
+    *(bc++) = '\0';
+    c++;
+
+    int err = config_loader_enter_section(loader, section);
+    if (err != 0) {
+        return 2;
+    }
+
+    char *field_value = c;
+    err = config_loader_load_field(loader, field_name, field_value);
+    if (err != 0) {
+        return 3;
+    }
+
+    return 0;
+}
+
+void config_set_default(struct config *config) {
+    for (int i = 0; i < sizeof(section_defs) / sizeof(section_defs[0]); i++) {
+        struct section_def *section_def = &section_defs[i];
+        for (struct field_def **field_def_ptr = section_def->fields;
+             *field_def_ptr != NULL; field_def_ptr++) {
+            struct field_def *field_def = *field_def_ptr;
+
+            int err = field_def->parse(
+                ((void *)config) + section_def->offset + field_def->offset,
+                field_def->default_value
+            );
+            if (err != 0) {
+                LOG_ERR(
+                    "Could not set default value '%s' for %s.%s.",
+                    field_def->default_value, section_def->name, field_def->name
+                );
+            }
+        }
+    }
+}
+
+void config_free_values(struct config *config) {
+    for (int i = 0; i < sizeof(section_defs) / sizeof(section_defs[0]); i++) {
+        struct section_def *section_def = &section_defs[i];
+        for (struct field_def **field_def_ptr = section_def->fields;
+             *field_def_ptr != NULL; field_def_ptr++) {
+            struct field_def *field_def = *field_def_ptr;
+
+            field_def->free(
+                ((void *)config) + section_def->offset + field_def->offset
+            );
+        }
+    }
+}

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,88 @@
+#ifndef __SURFACE_CONFIG_H_INCLUDED__
+#define __SURFACE_CONFIG_H_INCLUDED__
+
+#include <stdint.h>
+
+struct general_config {
+    char **home_row_keys;
+};
+
+struct mode_tile_config {
+    uint32_t label_color;
+    uint32_t label_select_color;
+    uint32_t unselectable_bg_color;
+    uint32_t selectable_bg_color;
+    uint32_t selectable_border_color;
+};
+
+struct mode_bisect_config {
+    uint32_t label_color;
+    double   label_font_size;
+    double   label_padding;
+
+    double  pointer_size;
+    int32_t pointer_color;
+
+    uint32_t unselectable_bg_color;
+    uint32_t even_area_bg_color;
+    uint32_t even_area_border_color;
+    uint32_t odd_area_bg_color;
+    uint32_t odd_area_border_color;
+
+    uint32_t history_border_color;
+};
+
+struct config {
+    struct general_config     general;
+    struct mode_tile_config   mode_tile;
+    struct mode_bisect_config mode_bisect;
+};
+
+/**
+ * The `config_loader` structure stores necesarry states to set parse values.
+ */
+struct config_loader {
+    struct config *config;
+    void          *curr_section_def;
+};
+
+/**
+ * `config_set_default` sets default values set in the configuration's
+ * definitions.
+ */
+void config_set_default(struct config *config);
+
+/**
+ * `config_free_values` frees configuration fields' values. This doesn't free
+ * the `config` structure itself.
+ */
+void config_free_values(struct config *config);
+
+/**
+ * `config_loader_init` initialise the `config_loader` structure.
+ */
+void config_loader_init(
+    struct config_loader *config_loader, struct config *config
+);
+
+/**
+ * `config_loader_enter_section` sets the current section's state. Following
+ * calls to `config_loader_load_field` will load fields for the given section.
+ */
+int config_loader_enter_section(struct config_loader *loader, char *section);
+
+/**
+ * `config_loader_load_field` loads the give field value from the current
+ * section.
+ */
+int config_loader_load_field(
+    struct config_loader *loader, char *name, char *value
+);
+
+/**
+ * `config_loader_load_cli_param` loads a configuration value from a CLI
+ * parameter value, e.g. `mode_bisect.label_color=#66666666`.
+ */
+int config_loader_load_cli_param(struct config_loader *loader, char *value);
+
+#endif

--- a/src/mode_tile.c
+++ b/src/mode_tile.c
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "mode.h"
 #include "state.h"
 #include "utils.h"
@@ -82,7 +83,7 @@ static void idx_to_label(
             unselected_part = true;
         }
 
-        curr_label = stpcpy(curr_label, home_row[idx % 8]);
+        curr_label  = stpcpy(curr_label, home_row[idx % 8]);
         idx        /= 8;
     }
 }
@@ -184,11 +185,11 @@ tile_mode_key(struct state *state, xkb_keysym_t keysym, char *text) {
 }
 
 void tile_mode_render(struct state *state, cairo_t *cairo) {
-
-    char                    label_selected[32];
-    char                    label_unselected[32];
-    int                     count = 0;
-    struct tile_mode_state *ms    = &state->mode_state.tile;
+    struct mode_tile_config *config = &state->config.mode_tile;
+    char                     label_selected[32];
+    char                     label_unselected[32];
+    int                      count = 0;
+    struct tile_mode_state  *ms    = &state->mode_state.tile;
 
     cairo_select_font_face(
         cairo, "sans-serif", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL
@@ -196,12 +197,12 @@ void tile_mode_render(struct state *state, cairo_t *cairo) {
     cairo_set_font_size(cairo, (int)(ms->sub_area_height / 2));
 
     cairo_set_operator(cairo, CAIRO_OPERATOR_SOURCE);
-    cairo_set_source_rgba(cairo, .2, .2, .2, .3);
+    cairo_set_source_u32(cairo, config->unselectable_bg_color);
     cairo_paint(cairo);
 
     cairo_translate(cairo, state->initial_area.x, state->initial_area.y);
 
-    cairo_set_source_rgba(cairo, .2, .2, .2, .7);
+    cairo_set_source_u32(cairo, config->unselectable_bg_color);
     cairo_rectangle(
         cairo, .5, .5, state->initial_area.w - 1, state->initial_area.h - 1
     );
@@ -225,11 +226,11 @@ void tile_mode_render(struct state *state, cairo_t *cairo) {
 
             cairo_set_operator(cairo, CAIRO_OPERATOR_SOURCE);
             if (selectable) {
-                cairo_set_source_rgba(cairo, 0, .2, 0, .3);
+                cairo_set_source_u32(cairo, config->selectable_bg_color);
                 cairo_rectangle(cairo, x, y, w, h);
                 cairo_fill(cairo);
 
-                cairo_set_source_rgba(cairo, 0, .3, 0, .7);
+                cairo_set_source_u32(cairo, config->selectable_border_color);
                 cairo_rectangle(cairo, x + .5, y + .5, w - 1, h - 1);
                 cairo_set_line_width(cairo, 1);
                 cairo_stroke(cairo);
@@ -248,13 +249,13 @@ void tile_mode_render(struct state *state, cairo_t *cairo) {
                     cairo,
                     x + (w - te_selected.x_advance - te_unselected.x_advance) /
                             2,
-                    y + (int
-                        )((h + max(te_selected.height, te_unselected.height)) /
-                          2)
+                    y + (int)((h + max(te_selected.height, te_unselected.height)
+                              ) /
+                              2)
                 );
-                cairo_set_source_rgba(cairo, 1, .8, 0, .9);
+                cairo_set_source_u32(cairo, config->label_select_color);
                 cairo_show_text(cairo, label_selected);
-                cairo_set_source_rgba(cairo, 1, 1, 1, .9);
+                cairo_set_source_u32(cairo, config->label_color);
                 cairo_show_text(cairo, label_unselected);
             }
 

--- a/src/state.h
+++ b/src/state.h
@@ -1,6 +1,7 @@
 #ifndef __SURFACE_STATE_H_INCLUDED__
 #define __SURFACE_STATE_H_INCLUDED__
 
+#include "config.h"
 #include "surface-buffer.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 #include "wlr-virtual-pointer-unstable-v1-client-protocol.h"
@@ -79,6 +80,7 @@ struct seat {
 };
 
 struct state {
+    struct config                           config;
     struct wl_display                      *wl_display;
     struct wl_registry                     *wl_registry;
     struct wl_compositor                   *wl_compositor;

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,3 +1,5 @@
+#include <cairo.h>
+#include <stdint.h>
 #include <string.h>
 
 int min(int a, int b) {
@@ -18,4 +20,12 @@ int find_str(char **strs, size_t len, char *to_find) {
     }
 
     return matched_i;
+}
+
+void cairo_set_source_u32(void *cairo, uint32_t color) {
+    cairo_set_source_rgba(
+        (cairo_t *)cairo, (color >> 24 & 0xff) / 255.0,
+        (color >> 16 & 0xff) / 255.0, (color >> 8 & 0xff) / 255.0,
+        (color & 0xff) / 255.0
+    );
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,5 +1,8 @@
 #include <stddef.h>
+#include <stdint.h>
 
 int max(int a, int b);
 int min(int a, int b);
 int find_str(char **strs, size_t len, char *to_find);
+
+void cairo_set_source_u32(void *cairo, uint32_t color);


### PR DESCRIPTION
The aim of this MR is for the user to be able to set their configuration through the a configuration file and CLI parameters.

For example, the file would look like this:

```ini
[mode_tile]
label_color=#fffd
label_select_color=#fd0d
selectable_bg_color=#0304
selectable_border_color=#040c
```

The program would look for the configuration file in these places:
- `$XDG_CONFIG_HOME/wl-kbptr/config`
- `~/.config/wl-kbptr/config`
- `/etc/wl-kbptr`

The same configuration could be passed (or overridden) by passing options to the CLI like so:

```bash
wl-kbptr \
  -o mode_tile.label_color=fffd \
  -o mode_tile.label_select_color=fd0d \
  -o mode_tile.selectable_bg_color=0304 \
  -o mode_tile.selectable_border_color=040c
```

## TODO

### This MR

- [x] Define configurable parameters
- [x] Define defaults
- [x] Make use of configuration:
  - [x] Tile mode colors
  - [x] Bisect mode colors
  - [x] Keybindings
- [x] Parse configuration values
- [x] Parse CLI arguments

### Subsequent MRs
- [ ] Parse configuration file
- [ ] Documentation and discoverability
- [ ] Tests
- [ ] Improved error handling