### PR TITLE
Feat: Tile mode config improvements

### DIFF
--- a/config.example
+++ b/config.example
@@ -14,6 +14,7 @@ selectable_bg_color=#0304
 selectable_border_color=#040c
 max_num_sub_areas=512
 min_sub_area_size=1250
+enable_bisect=true
 
 [mode_bisect]
 label_color=#fffd

--- a/config.example
+++ b/config.example
@@ -12,41 +12,14 @@ label_select_color=#fd0d
 unselectable_bg_color=#2226
 selectable_bg_color=#0304
 selectable_border_color=#040c
+max_num_sub_areas=512
+min_sub_area_size=1250
 
 [mode_bisect]
 label_color=#fffd
-label_font_size=20
-label_padding=12
-pointer_size=20
-pointer_color=#e22d
-unselectable_bg_color=#2226
-even_area_bg_color=#0304
-even_area_border_color=#0408
-odd_area_bg_color=#0034
-odd_area_border_color=#0048
-history_border_color=#3339
-# wl-kbptr can be configured with a configuration file.
-# The file location can be passed with the -C parameter.
-# Othewise the `$XDG_CONFIG_HOME/wl-kbptr/config` file will
-# be loaded if it exits. Below is the default configuration.
-
-[general]
-home_row_keys=
-
-[mode_tile]
-label_color=#fffd
-label_select_color=#fd0d
-unselectable_bg_color=#2226
-selectable_bg_color=#0304
-selectable_border_color=#040c
-label_font_family=sans-serif
-
-[mode_bisect]
-label_color=#fffd
-label_font_size=20
-label_font_family=sans-serif
-label_padding=12
-pointer_size=20
+label_font_size=80
+label_padding=32
+pointer_size=40
 pointer_color=#e22d
 unselectable_bg_color=#2226
 even_area_bg_color=#0304

--- a/config.example
+++ b/config.example
@@ -15,6 +15,7 @@ selectable_border_color=#040c
 max_num_sub_areas=512
 min_sub_area_size=1250
 enable_bisect=true
+area_font_percentage=0.5
 
 [mode_bisect]
 label_color=#fffd

--- a/src/config.c
+++ b/src/config.c
@@ -4,6 +4,7 @@
 #include "state.h"
 
 #include <errno.h>
+#include <limits.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -82,6 +83,16 @@ static int parse_color(void *dest, char *value) {
 static int parse_double(void *dest, char *value) {
     *((double *)dest) = atof(value);
     // TODO: handle errors better.
+    return 0;
+}
+
+static int parse_int(void *dest, char *value) {
+    char *endptr;
+    long val = strtol(value, &endptr, 10);
+    if (*endptr != '\0' || val < 0 || val > INT_MAX) {
+        return 1;
+    }
+    *((int *)dest) = (int)val;
     return 0;
 }
 
@@ -218,12 +229,15 @@ static struct section_def section_defs[] = {
         G_FIELD(home_row_keys, "", parse_home_row_keys, free_home_row_keys)
     ),
     SECTION(
-        mode_tile, MT_FIELD(label_color, "#fffd", parse_color, noop),
+        mode_tile, 
+        MT_FIELD(label_color, "#fffd", parse_color, noop),
         MT_FIELD(label_select_color, "#fd0d", parse_color, noop),
         MT_FIELD(unselectable_bg_color, "#2226", parse_color, noop),
         MT_FIELD(selectable_bg_color, "#0304", parse_color, noop),
         MT_FIELD(selectable_border_color, "#040c", parse_color, noop),
-        MT_FIELD(label_font_family, "sans-serif", parse_str, free_str)
+        MT_FIELD(label_font_family, "sans-serif", parse_str, free_str),
+        MT_FIELD(max_num_sub_areas, "512", parse_int, noop),    // (8*8*8)
+        MT_FIELD(min_sub_area_size, "1250", parse_int, noop)    // (25*50)
     ),
     SECTION(
         mode_bisect, MB_FIELD(label_color, "#fffd", parse_color, noop),

--- a/src/config.c
+++ b/src/config.c
@@ -96,6 +96,18 @@ static int parse_int(void *dest, char *value) {
     return 0;
 }
 
+
+static int parse_bool(void *dest, char *value) {
+    if (strcmp(value, "true") == 0 || strcmp(value, "1") == 0) {
+        *((bool *)dest) = true;
+        return 0;
+    } else if (strcmp(value, "false") == 0 || strcmp(value, "0") == 0) {
+        *((bool *)dest) = false;
+        return 0;
+    }
+    return 1;
+}
+
 static int parse_home_row_keys(void *dest, char *value) {
     char ***home_row_keys_ptr = dest;
 
@@ -229,15 +241,16 @@ static struct section_def section_defs[] = {
         G_FIELD(home_row_keys, "", parse_home_row_keys, free_home_row_keys)
     ),
     SECTION(
-        mode_tile, 
+        mode_tile,
         MT_FIELD(label_color, "#fffd", parse_color, noop),
         MT_FIELD(label_select_color, "#fd0d", parse_color, noop),
         MT_FIELD(unselectable_bg_color, "#2226", parse_color, noop),
         MT_FIELD(selectable_bg_color, "#0304", parse_color, noop),
         MT_FIELD(selectable_border_color, "#040c", parse_color, noop),
         MT_FIELD(label_font_family, "sans-serif", parse_str, free_str),
-        MT_FIELD(max_num_sub_areas, "512", parse_int, noop),    // (8*8*8)
-        MT_FIELD(min_sub_area_size, "1250", parse_int, noop)    // (25*50)
+        MT_FIELD(max_num_sub_areas, "512", parse_int, noop),
+        MT_FIELD(min_sub_area_size, "1250", parse_int, noop),
+        MT_FIELD(enable_bisect, "true", parse_bool, noop)
     ),
     SECTION(
         mode_bisect, MB_FIELD(label_color, "#fffd", parse_color, noop),
@@ -572,3 +585,4 @@ err:
     fclose(f);
     return 1;
 }
+

--- a/src/config.c
+++ b/src/config.c
@@ -250,7 +250,8 @@ static struct section_def section_defs[] = {
         MT_FIELD(label_font_family, "sans-serif", parse_str, free_str),
         MT_FIELD(max_num_sub_areas, "512", parse_int, noop),
         MT_FIELD(min_sub_area_size, "1250", parse_int, noop),
-        MT_FIELD(enable_bisect, "true", parse_bool, noop)
+        MT_FIELD(enable_bisect, "true", parse_bool, noop),
+        MT_FIELD(area_font_percentage, "0.5", parse_double, noop)
     ),
     SECTION(
         mode_bisect, MB_FIELD(label_color, "#fffd", parse_color, noop),

--- a/src/config.h
+++ b/src/config.h
@@ -15,6 +15,8 @@ struct mode_tile_config {
     uint32_t selectable_bg_color;
     uint32_t selectable_border_color;
     char    *label_font_family;
+    int      max_num_sub_areas;
+    int      min_sub_area_size;
 };
 
 struct mode_bisect_config {

--- a/src/config.h
+++ b/src/config.h
@@ -19,6 +19,7 @@ struct mode_tile_config {
     int      max_num_sub_areas;
     int      min_sub_area_size;
     bool     enable_bisect;
+    double   area_font_percentage;
 };
 
 struct mode_bisect_config {

--- a/src/config.h
+++ b/src/config.h
@@ -2,6 +2,7 @@
 #define __CONFIG_H_INCLUDED__
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <stdio.h>
 
 struct general_config {
@@ -17,6 +18,7 @@ struct mode_tile_config {
     char    *label_font_family;
     int      max_num_sub_areas;
     int      min_sub_area_size;
+    bool     enable_bisect;
 };
 
 struct mode_bisect_config {

--- a/src/mode_tile.c
+++ b/src/mode_tile.c
@@ -253,7 +253,7 @@ void tile_mode_render(struct state *state, cairo_t *cairo) {
         cairo, config->label_font_family, CAIRO_FONT_SLANT_NORMAL,
         CAIRO_FONT_WEIGHT_NORMAL
     );
-    cairo_set_font_size(cairo, (int)(ms->sub_area_height / 2));
+    cairo_set_font_size(cairo, (int)(ms->sub_area_height * config->area_font_percentage));
 
     cairo_set_operator(cairo, CAIRO_OPERATOR_SOURCE);
     cairo_set_source_u32(cairo, config->unselectable_bg_color);

--- a/src/mode_tile.c
+++ b/src/mode_tile.c
@@ -9,8 +9,6 @@
 #include <string.h>
 #include <xkbcommon/xkbcommon.h>
 
-#define MIN_SUB_AREA_SIZE (25 * 50)
-
 static char determine_label_length(struct tile_mode_state *ms) {
     int areas = ms->sub_area_columns * ms->sub_area_rows;
     if (areas <= 8) {
@@ -69,10 +67,10 @@ void tile_mode_enter(struct state *state) {
         return;
     }
 
-    const int max_num_sub_areas = 8 * 8 * 8;
-    const int area_size         = state->initial_area.w * state->initial_area.h;
+    const struct mode_tile_config *config = &state->config.mode_tile;
+    const int area_size = state->initial_area.w * state->initial_area.h;
     const int sub_area_size =
-        max(area_size / max_num_sub_areas, MIN_SUB_AREA_SIZE);
+        max(area_size / config->max_num_sub_areas, config->min_sub_area_size);
 
     struct tile_mode_state *ms = &state->mode_state.tile;
 


### PR DESCRIPTION
Added 3 features in the config to make using tile mode more customizable/flexible for various setups. This includes:

- Adjusting area sizes/number of areas by exposing the two hardcoded underlying values as config values
- Scaling the font size inside of a tile area, defaulting to base 0.5 and adjusting as needed
- Skipping bisection entirely for those who just want to use tile mode alone without having to press space/enter after 

These were pretty high-value updates on my end for my flow, and should be helpful to someone else out there.