### PR TITLE
Add split mode

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -43,6 +43,7 @@ sources = [
   'src/mode_tile.c',
   'src/mode_floating.c',
   'src/mode_bisect.c',
+  'src/mode_split.c',
   'src/mode_click.c',
   'src/utils.c',
   'src/utils_cairo.c',

--- a/src/config.c
+++ b/src/config.c
@@ -254,6 +254,8 @@ struct section_def {
     FIELD(struct mode_floating_config, name, default_value, parse, free)
 #define MB_FIELD(name, default_value, parse, free) \
     FIELD(struct mode_bisect_config, name, default_value, parse, free)
+#define MS_FIELD(name, default_value, parse, free) \
+    FIELD(struct mode_split_config, name, default_value, parse, free)
 #define MC_FIELD(name, default_value, parse, free) \
     FIELD(struct mode_click_config, name, default_value, parse, free)
 
@@ -305,6 +307,16 @@ static struct section_def section_defs[] = {
         MB_FIELD(odd_area_bg_color, "#0034", parse_color, noop),
         MB_FIELD(odd_area_border_color, "#0048", parse_color, noop),
         MB_FIELD(history_border_color, "#3339", parse_color, noop)
+    ),
+    SECTION(
+        mode_split, MS_FIELD(pointer_size, "20", parse_double, noop),
+        MS_FIELD(pointer_color, "#e22d", parse_color, noop),
+        MS_FIELD(unselectable_bg_color, "#2226", parse_color, noop),
+        MS_FIELD(even_area_bg_color, "#0304", parse_color, noop),
+        MS_FIELD(even_area_border_color, "#0408", parse_color, noop),
+        MS_FIELD(odd_area_bg_color, "#0034", parse_color, noop),
+        MS_FIELD(odd_area_border_color, "#0048", parse_color, noop),
+        MS_FIELD(history_border_color, "#3339", parse_color, noop)
     ),
     SECTION(mode_click, MC_FIELD(button, "left", parse_click, noop)),
 };

--- a/src/config.c
+++ b/src/config.c
@@ -311,11 +311,9 @@ static struct section_def section_defs[] = {
     SECTION(
         mode_split, MS_FIELD(pointer_size, "20", parse_double, noop),
         MS_FIELD(pointer_color, "#e22d", parse_color, noop),
-        MS_FIELD(unselectable_bg_color, "#2226", parse_color, noop),
-        MS_FIELD(even_area_bg_color, "#0304", parse_color, noop),
-        MS_FIELD(even_area_border_color, "#0408", parse_color, noop),
-        MS_FIELD(odd_area_bg_color, "#0034", parse_color, noop),
-        MS_FIELD(odd_area_border_color, "#0048", parse_color, noop),
+        MS_FIELD(bg_color, "#2226", parse_color, noop),
+        MS_FIELD(vertical_color, "#8888ffcc", parse_color, noop),
+        MS_FIELD(horizontal_color, "#008800cc", parse_color, noop),
         MS_FIELD(history_border_color, "#3339", parse_color, noop)
     ),
     SECTION(mode_click, MC_FIELD(button, "left", parse_click, noop)),

--- a/src/config.c
+++ b/src/config.c
@@ -312,6 +312,7 @@ static struct section_def section_defs[] = {
         mode_split, MS_FIELD(pointer_size, "20", parse_double, noop),
         MS_FIELD(pointer_color, "#e22d", parse_color, noop),
         MS_FIELD(bg_color, "#2226", parse_color, noop),
+        MS_FIELD(area_bg_color, "#11111188", parse_color, noop),
         MS_FIELD(vertical_color, "#8888ffcc", parse_color, noop),
         MS_FIELD(horizontal_color, "#008800cc", parse_color, noop),
         MS_FIELD(history_border_color, "#3339", parse_color, noop)

--- a/src/config.h
+++ b/src/config.h
@@ -59,6 +59,7 @@ struct mode_split_config {
     int32_t pointer_color;
 
     uint32_t bg_color;
+    uint32_t area_bg_color;
     uint32_t vertical_color;
     uint32_t horizontal_color;
 

--- a/src/config.h
+++ b/src/config.h
@@ -54,6 +54,24 @@ struct mode_bisect_config {
     uint32_t history_border_color;
 };
 
+struct mode_split_config {
+    uint32_t label_color;
+    double   label_font_size;
+    char    *label_font_family;
+    double   label_padding;
+
+    double  pointer_size;
+    int32_t pointer_color;
+
+    uint32_t unselectable_bg_color;
+    uint32_t even_area_bg_color;
+    uint32_t even_area_border_color;
+    uint32_t odd_area_bg_color;
+    uint32_t odd_area_border_color;
+
+    uint32_t history_border_color;
+};
+
 struct mode_click_config {
     enum click button;
 };
@@ -63,6 +81,7 @@ struct config {
     struct mode_tile_config     mode_tile;
     struct mode_floating_config mode_floating;
     struct mode_bisect_config   mode_bisect;
+    struct mode_split_config    mode_split;
     struct mode_click_config    mode_click;
 };
 

--- a/src/config.h
+++ b/src/config.h
@@ -55,11 +55,6 @@ struct mode_bisect_config {
 };
 
 struct mode_split_config {
-    uint32_t label_color;
-    double   label_font_size;
-    char    *label_font_family;
-    double   label_padding;
-
     double  pointer_size;
     int32_t pointer_color;
 

--- a/src/config.h
+++ b/src/config.h
@@ -58,11 +58,9 @@ struct mode_split_config {
     double  pointer_size;
     int32_t pointer_color;
 
-    uint32_t unselectable_bg_color;
-    uint32_t even_area_bg_color;
-    uint32_t even_area_border_color;
-    uint32_t odd_area_bg_color;
-    uint32_t odd_area_border_color;
+    uint32_t bg_color;
+    uint32_t vertical_color;
+    uint32_t horizontal_color;
 
     uint32_t history_border_color;
 };

--- a/src/mode.c
+++ b/src/mode.c
@@ -8,12 +8,14 @@
 extern struct mode_interface tile_mode_interface;
 extern struct mode_interface floating_mode_interface;
 extern struct mode_interface bisect_mode_interface;
+extern struct mode_interface split_mode_interface;
 extern struct mode_interface click_mode_interface;
 
 struct mode_interface *mode_interfaces[] = {
     &tile_mode_interface,
     &floating_mode_interface,
     &bisect_mode_interface,
+    &split_mode_interface,
     &click_mode_interface,
     NULL,
 };

--- a/src/mode.c
+++ b/src/mode.c
@@ -12,12 +12,8 @@ extern struct mode_interface split_mode_interface;
 extern struct mode_interface click_mode_interface;
 
 struct mode_interface *mode_interfaces[] = {
-    &tile_mode_interface,
-    &floating_mode_interface,
-    &bisect_mode_interface,
-    &split_mode_interface,
-    &click_mode_interface,
-    NULL,
+    &tile_mode_interface,  &floating_mode_interface, &bisect_mode_interface,
+    &split_mode_interface, &click_mode_interface,    NULL,
 };
 
 static struct mode_interface *find_mode_interface_by_name(char *name) {

--- a/src/mode_split.c
+++ b/src/mode_split.c
@@ -136,55 +136,6 @@ static void division_4_or_8_render(
             cairo_stroke(cairo);
         }
     }
-
-    cairo_select_font_face(
-        cairo, config->label_font_family, CAIRO_FONT_SLANT_NORMAL,
-        CAIRO_FONT_WEIGHT_NORMAL
-    );
-    cairo_set_font_size(cairo, config->label_font_size);
-    cairo_set_source_u32(cairo, config->label_color);
-    char label[64];
-
-    // Top label
-    if (divide_8) {
-        snprintf(
-            label, sizeof(label), "%s %s %s %s", state->home_row[0],
-            state->home_row[1], state->home_row[2], state->home_row[3]
-        );
-    } else {
-        snprintf(
-            label, sizeof(label), "%s %s", state->home_row[0],
-            state->home_row[1]
-        );
-    }
-
-    cairo_text_extents_t te;
-    cairo_text_extents(cairo, label, &te);
-    cairo_move_to(
-        cairo, area->x + (int)(area->w / 2) - (int)(te.width / 2),
-        area->y - config->label_padding
-    );
-    cairo_show_text(cairo, label);
-
-    // Bottom label
-    if (divide_8) {
-        snprintf(
-            label, sizeof(label), "%s %s %s %s", state->home_row[4],
-            state->home_row[5], state->home_row[6], state->home_row[7]
-        );
-    } else {
-        snprintf(
-            label, sizeof(label), "%s %s", state->home_row[2],
-            state->home_row[3]
-        );
-    }
-
-    cairo_text_extents(cairo, label, &te);
-    cairo_move_to(
-        cairo, area->x + (int)(area->w / 2) - (int)(te.width / 2),
-        area->y + area->h + te.height + config->label_padding
-    );
-    cairo_show_text(cairo, label);
 }
 
 static bool division_4_or_8_idx_to_rect(
@@ -231,23 +182,6 @@ static void division_horizontal_render(
     cairo_move_to(cairo, area->x + (int)(area->w / 2) + .5, area->y + .5);
     cairo_line_to(cairo, area->x + area->w + .5, area->y + .5);
     cairo_stroke(cairo);
-
-    cairo_set_source_u32(cairo, config->label_color);
-
-    cairo_text_extents_t te;
-    cairo_text_extents(cairo, state->home_row[0], &te);
-    cairo_move_to(
-        cairo, area->x - config->label_padding - te.width,
-        area->y + te.height / 2
-    );
-    cairo_show_text(cairo, state->home_row[0]);
-
-    cairo_text_extents(cairo, state->home_row[1], &te);
-    cairo_move_to(
-        cairo, area->x + area->w + config->label_padding,
-        area->y + te.height / 2
-    );
-    cairo_show_text(cairo, state->home_row[1]);
 }
 
 static bool division_horizontal_idx_to_rect(
@@ -283,22 +217,6 @@ static void division_vertical_render(
     cairo_move_to(cairo, area->x + .5, area->y + .5 + (int)(area->h / 2));
     cairo_line_to(cairo, area->x + .5, area->y + .5 + area->h);
     cairo_stroke(cairo);
-
-    cairo_set_source_u32(cairo, config->label_color);
-
-    cairo_text_extents_t te;
-    cairo_text_extents(cairo, state->home_row[0], &te);
-    cairo_move_to(
-        cairo, area->x - te.width / 2, area->y - config->label_padding
-    );
-    cairo_show_text(cairo, state->home_row[0]);
-
-    cairo_text_extents(cairo, state->home_row[1], &te);
-    cairo_move_to(
-        cairo, area->x - te.width / 2,
-        area->y + area->h + config->label_padding + te.height
-    );
-    cairo_show_text(cairo, state->home_row[1]);
 }
 
 static bool division_vertical_idx_to_rect(

--- a/src/mode_split.c
+++ b/src/mode_split.c
@@ -1,0 +1,484 @@
+#include "config.h"
+#include "mode.h"
+#include "state.h"
+#include "utils.h"
+#include "utils_cairo.h"
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define DIVIDE_8_RATIO 1.8
+
+enum bisect_division {
+    /*
+     * The tiling mode should give us areas that are twice as wide as they are
+     * tall. In this case, we want to divide the area in 8 instead of 4 as to
+     * then get equal square areas.
+     *
+     *  +--+--+--+--+
+     *  | 0| 1| 2| 3|
+     *  +--+--+--+--+
+     *  | 4| 5| 6| 7|
+     *  +--+--+--+--+
+     */
+    DIVISION_8 = 0,
+    /*
+     * After the first pass, we should only get mostly square areas.
+     *
+     *  +--+--+
+     *  | 0| 1|
+     *  +--+--+
+     *  | 2| 3|
+     *  +--+--+
+     */
+    DIVISION_4,
+    /*
+     * Once we have divide the areas enough times, we will end up with a line,
+     * i.e. a area with a width or height of a single pixel. In this case we
+     * divide the area in two.
+     *
+     *    0  1
+     *  +--+--+
+     */
+    DIVISION_HORIZONTAL,
+    /*
+     *    +
+     *    | 0
+     *    +
+     *    | 1
+     *    +
+     */
+    DIVISION_VERTICAL,
+    /*
+     * Given enough divisions, we should end up with a single pixel.
+     *
+     *    +
+     */
+    UNDIVIDABLE,
+};
+
+void *split_mode_enter(struct state *state, struct rect area) {
+    struct split_mode_state *ms = malloc(sizeof(struct split_mode_state));
+    ms->areas[0]                = area;
+    ms->current                 = 0;
+
+    return ms;
+}
+
+static enum bisect_division determine_division(struct rect *area) {
+    if (area->w <= 1 && area->h <= 1) {
+        return UNDIVIDABLE;
+    }
+
+    if (area->w <= 1) {
+        return DIVISION_VERTICAL;
+    }
+
+    if (area->h <= 1) {
+        return DIVISION_HORIZONTAL;
+    }
+
+    return area->w > area->h * DIVIDE_8_RATIO ? DIVISION_8 : DIVISION_4;
+}
+
+struct division_interface {
+    void (*render)(enum bisect_division, struct state *, struct split_mode_state *ms, cairo_t *);
+
+    // `idx_to_sub_area` returns the sub-area indicated by the given index in
+    // `rect` while also returning true. If the index does map to a sub-area,
+    // `rect` is left unchanged and it returns false.
+    bool (*idx_to_sub_area)(
+        enum bisect_division, int idx, struct rect *current_area,
+        struct rect *new_area
+    );
+};
+
+static void division_4_or_8_render(
+    enum bisect_division division, struct state *state,
+    struct split_mode_state *ms, cairo_t *cairo
+) {
+    struct mode_split_config *config = &state->config.mode_split;
+    struct rect              *area   = &ms->areas[ms->current];
+
+    bool divide_8 = division == DIVISION_8;
+
+    const int sub_area_columns = divide_8 ? 4 : 2;
+    const int sub_area_rows    = 2;
+
+    const int sub_area_width      = area->w / sub_area_columns;
+    const int sub_area_width_off  = area->w % sub_area_columns;
+    const int sub_area_height     = area->h / sub_area_rows;
+    const int sub_area_height_off = area->h % sub_area_rows;
+
+    for (int i = 0; i < sub_area_columns; i++) {
+        for (int j = 0; j < sub_area_rows; j++) {
+            const int x =
+                area->x + i * sub_area_width + min(i, sub_area_width_off);
+            const int y =
+                area->y + j * sub_area_height + min(j, sub_area_height_off);
+            const int w = sub_area_width + (i < sub_area_width_off ? 1 : 0);
+            const int h = sub_area_height + (j < sub_area_height_off ? 1 : 0);
+
+            cairo_set_source_u32(
+                cairo, (i + j) % 2 == 0 ? config->even_area_bg_color
+                                        : config->odd_area_bg_color
+            );
+            cairo_rectangle(cairo, x, y, w, h);
+            cairo_fill(cairo);
+
+            cairo_set_line_width(cairo, 1);
+            cairo_rectangle(cairo, x + .5, y + .5, w - 1, h - 1);
+            cairo_set_source_u32(
+                cairo, (i + j) % 2 == 0 ? config->even_area_border_color
+                                        : config->odd_area_border_color
+            );
+            cairo_stroke(cairo);
+        }
+    }
+
+    cairo_select_font_face(
+        cairo, config->label_font_family, CAIRO_FONT_SLANT_NORMAL,
+        CAIRO_FONT_WEIGHT_NORMAL
+    );
+    cairo_set_font_size(cairo, config->label_font_size);
+    cairo_set_source_u32(cairo, config->label_color);
+    char label[64];
+
+    // Top label
+    if (divide_8) {
+        snprintf(
+            label, sizeof(label), "%s %s %s %s", state->home_row[0],
+            state->home_row[1], state->home_row[2], state->home_row[3]
+        );
+    } else {
+        snprintf(
+            label, sizeof(label), "%s %s", state->home_row[0],
+            state->home_row[1]
+        );
+    }
+
+    cairo_text_extents_t te;
+    cairo_text_extents(cairo, label, &te);
+    cairo_move_to(
+        cairo, area->x + (int)(area->w / 2) - (int)(te.width / 2),
+        area->y - config->label_padding
+    );
+    cairo_show_text(cairo, label);
+
+    // Bottom label
+    if (divide_8) {
+        snprintf(
+            label, sizeof(label), "%s %s %s %s", state->home_row[4],
+            state->home_row[5], state->home_row[6], state->home_row[7]
+        );
+    } else {
+        snprintf(
+            label, sizeof(label), "%s %s", state->home_row[2],
+            state->home_row[3]
+        );
+    }
+
+    cairo_text_extents(cairo, label, &te);
+    cairo_move_to(
+        cairo, area->x + (int)(area->w / 2) - (int)(te.width / 2),
+        area->y + area->h + te.height + config->label_padding
+    );
+    cairo_show_text(cairo, label);
+}
+
+static bool division_4_or_8_idx_to_rect(
+    enum bisect_division division, int idx, struct rect *area, struct rect *rect
+) {
+    bool divide_8 = division == DIVISION_8;
+    if (!divide_8 && idx >= 4) {
+        return false;
+    }
+
+    const int sub_area_columns = divide_8 ? 4 : 2;
+    const int sub_area_rows    = 2;
+
+    const int sub_area_width      = area->w / sub_area_columns;
+    const int sub_area_width_off  = area->w % sub_area_columns;
+    const int sub_area_height     = area->h / sub_area_rows;
+    const int sub_area_height_off = area->h % sub_area_rows;
+
+    const int i = idx % sub_area_columns;
+    const int j = idx / sub_area_columns;
+
+    rect->x = area->x + i * sub_area_width + min(i, sub_area_width_off);
+    rect->y = area->y + j * sub_area_height + min(j, sub_area_height_off);
+    rect->w = sub_area_width + (i < sub_area_width_off ? 1 : 0);
+    rect->h = sub_area_height + (j < sub_area_height_off ? 1 : 0);
+
+    return true;
+}
+
+static void division_horizontal_render(
+    enum bisect_division division, struct state *state,
+    struct split_mode_state *ms, cairo_t *cairo
+) {
+    struct mode_split_config *config = &state->config.mode_split;
+    struct rect               *area   = &ms->areas[ms->current];
+
+    cairo_set_source_u32(cairo, config->even_area_border_color);
+    cairo_set_line_width(cairo, 1);
+    cairo_move_to(cairo, area->x + .5, area->y + .5);
+    cairo_line_to(cairo, area->x + (int)(area->w / 2) - .5, area->y + .5);
+    cairo_stroke(cairo);
+
+    cairo_set_source_u32(cairo, config->odd_area_border_color);
+    cairo_move_to(cairo, area->x + (int)(area->w / 2) + .5, area->y + .5);
+    cairo_line_to(cairo, area->x + area->w + .5, area->y + .5);
+    cairo_stroke(cairo);
+
+    cairo_set_source_u32(cairo, config->label_color);
+
+    cairo_text_extents_t te;
+    cairo_text_extents(cairo, state->home_row[0], &te);
+    cairo_move_to(
+        cairo, area->x - config->label_padding - te.width,
+        area->y + te.height / 2
+    );
+    cairo_show_text(cairo, state->home_row[0]);
+
+    cairo_text_extents(cairo, state->home_row[1], &te);
+    cairo_move_to(
+        cairo, area->x + area->w + config->label_padding,
+        area->y + te.height / 2
+    );
+    cairo_show_text(cairo, state->home_row[1]);
+}
+
+static bool division_horizontal_idx_to_rect(
+    enum bisect_division division, int idx, struct rect *area, struct rect *rect
+) {
+    if (idx > 1) {
+        return false;
+    }
+
+    rect->x = area->x + idx * area->w / 2;
+    rect->y = area->y;
+    rect->w = area->w / 2;
+    rect->h = area->h;
+
+    return true;
+}
+
+static void division_vertical_render(
+    enum bisect_division division, struct state *state,
+    struct split_mode_state *ms, cairo_t *cairo
+) {
+
+    struct mode_split_config *config = &state->config.mode_split;
+    struct rect              *area   = &ms->areas[ms->current];
+
+    cairo_set_source_u32(cairo, config->even_area_border_color);
+    cairo_set_line_width(cairo, 1);
+    cairo_move_to(cairo, area->x + .5, area->y + .5);
+    cairo_line_to(cairo, area->x + .5, area->y - .5 + (int)(area->h / 2));
+    cairo_stroke(cairo);
+
+    cairo_set_source_u32(cairo, config->odd_area_border_color);
+    cairo_move_to(cairo, area->x + .5, area->y + .5 + (int)(area->h / 2));
+    cairo_line_to(cairo, area->x + .5, area->y + .5 + area->h);
+    cairo_stroke(cairo);
+
+    cairo_set_source_u32(cairo, config->label_color);
+
+    cairo_text_extents_t te;
+    cairo_text_extents(cairo, state->home_row[0], &te);
+    cairo_move_to(
+        cairo, area->x - te.width / 2, area->y - config->label_padding
+    );
+    cairo_show_text(cairo, state->home_row[0]);
+
+    cairo_text_extents(cairo, state->home_row[1], &te);
+    cairo_move_to(
+        cairo, area->x - te.width / 2,
+        area->y + area->h + config->label_padding + te.height
+    );
+    cairo_show_text(cairo, state->home_row[1]);
+}
+
+static bool division_vertical_idx_to_rect(
+    enum bisect_division division, int idx, struct rect *area, struct rect *rect
+) {
+    if (idx > 1) {
+        return false;
+    }
+
+    rect->x = area->x;
+    rect->y = area->y + idx * area->h / 2;
+    rect->w = area->w;
+    rect->h = area->h / 2;
+
+    return true;
+}
+
+static void undividable_render(
+    enum bisect_division division, struct state *state,
+    struct split_mode_state *ms, cairo_t *cairo
+) {
+    struct mode_split_config *config = &state->config.mode_split;
+    struct rect              *area   = &ms->areas[ms->current];
+
+    cairo_set_source_u32(cairo, config->pointer_color);
+    cairo_arc(
+        cairo, area->x + .5, area->y + .5, config->pointer_size / 4., 0,
+        2 * M_PI
+    );
+    cairo_set_line_width(cairo, 1);
+    cairo_stroke(cairo);
+}
+
+static bool undividable_select_idx() {
+    return false;
+}
+
+static const struct division_interface division_interfaces[] = {
+    [DIVISION_8] =
+        {.render          = division_4_or_8_render,
+         .idx_to_sub_area = division_4_or_8_idx_to_rect},
+    [DIVISION_4] =
+        {.render          = division_4_or_8_render,
+         .idx_to_sub_area = division_4_or_8_idx_to_rect},
+    [DIVISION_VERTICAL] =
+        {.render          = division_vertical_render,
+         .idx_to_sub_area = division_vertical_idx_to_rect},
+    [DIVISION_HORIZONTAL] =
+        {.render          = division_horizontal_render,
+         .idx_to_sub_area = division_horizontal_idx_to_rect},
+    [UNDIVIDABLE] =
+        {.render = undividable_render, .idx_to_sub_area = undividable_select_idx
+        },
+};
+
+static void
+split_mode_render(struct state *state, void *mode_state, cairo_t *cairo) {
+    struct mode_split_config *config = &state->config.mode_split;
+    struct split_mode_state  *ms     = mode_state;
+    struct rect              *area   = &ms->areas[ms->current];
+
+    cairo_set_operator(cairo, CAIRO_OPERATOR_SOURCE);
+    cairo_set_source_u32(cairo, config->unselectable_bg_color);
+    cairo_paint(cairo);
+
+    cairo_set_source_u32(cairo, config->history_border_color);
+    cairo_set_line_width(cairo, 1);
+
+    for (int i = 0; i < ms->current; i++) {
+        struct rect *area = &ms->areas[i];
+        cairo_rectangle(
+            cairo, area->x + .5, area->y + .5, area->w - 1, area->h - 1
+        );
+        cairo_stroke(cairo);
+    }
+
+    if (ms->current < BISECT_MAX_HISTORY) {
+        enum bisect_division division = determine_division(area);
+        division_interfaces[division].render(division, state, ms, cairo);
+    }
+
+    cairo_set_line_width(cairo, 1);
+    cairo_set_source_u32(cairo, config->pointer_color);
+    const int pointer_x = area->x + area->w / 2;
+    const int pointer_y = area->y + area->h / 2;
+    cairo_move_to(
+        cairo, pointer_x + .5, pointer_y - (int)(config->pointer_size / 2) + .5
+    );
+    cairo_line_to(
+        cairo, pointer_x + .5, pointer_y + (int)(config->pointer_size / 2) + .5
+    );
+    cairo_stroke(cairo);
+    cairo_move_to(
+        cairo, pointer_x - (int)(config->pointer_size / 2) + .5, pointer_y + .5
+    );
+    cairo_line_to(
+        cairo, pointer_x + (int)(config->pointer_size / 2) + .5, pointer_y + .5
+    );
+    cairo_stroke(cairo);
+}
+
+static bool split_mode_key(
+    struct state *state, void *mode_state, xkb_keysym_t keysym, char *text
+) {
+    struct split_mode_state *ms = mode_state;
+
+    switch (keysym) {
+    case XKB_KEY_Escape:
+        state->running = false;
+        break;
+
+    case XKB_KEY_Return:
+    case XKB_KEY_space:
+        enter_next_mode(state, ms->areas[ms->current]);
+        return true;
+
+    case XKB_KEY_BackSpace:
+        if (ms->current > 0) {
+            ms->current--;
+        } else {
+            reenter_prev_mode(state);
+        }
+        return true;
+
+    default:
+        if (ms->current + 1 >= BISECT_MAX_HISTORY) {
+            return false;
+        }
+
+        struct rect         *area     = &ms->areas[ms->current];
+        enum bisect_division division = determine_division(area);
+
+        int matched_i = find_str(state->home_row, HOME_ROW_LEN_WITH_BTN, text);
+        if (matched_i < 0) {
+            return false;
+        }
+
+        if (matched_i >= HOME_ROW_LEN) {
+            switch (matched_i) {
+            case HOME_ROW_LEFT_CLICK:
+                state->click = CLICK_LEFT_BTN;
+                break;
+            case HOME_ROW_RIGHT_CLICK:
+                state->click = CLICK_RIGHT_BTN;
+                break;
+            case HOME_ROW_MIDDLE_CLICK:
+                state->click = CLICK_MIDDLE_BTN;
+                break;
+            }
+
+            enter_next_mode(state, ms->areas[ms->current]);
+            return false;
+        }
+
+        if (division == UNDIVIDABLE) {
+            return false;
+        }
+
+        struct rect *new_area = &ms->areas[ms->current + 1];
+        if (division_interfaces[division].idx_to_sub_area(
+                division, matched_i, area, new_area
+            )) {
+            ms->current++;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void split_mode_reenter(struct state *state, void *mode_state) {}
+void split_mode_free(void *mode_state) {
+    free(mode_state);
+}
+
+struct mode_interface split_mode_interface = {
+    .name    = "split",
+    .enter   = split_mode_enter,
+    .reenter = split_mode_reenter,
+    .key     = split_mode_key,
+    .render  = split_mode_render,
+    .free    = split_mode_free,
+};

--- a/src/mode_split.c
+++ b/src/mode_split.c
@@ -62,6 +62,8 @@ static void split_mode_render_cursor(
 static void render_split_render_arrow(
     cairo_t *cairo, int x, int y, enum split_dir dir, uint32_t color
 ) {
+#define SIMPLE_ARROWS
+#if !defined(SIMPLE_ARROWS)
     char *label;
     switch (dir) {
     case SPLIT_DIR_LEFT:
@@ -96,6 +98,50 @@ static void render_split_render_arrow(
     cairo_move_to(cairo, x - te.x_advance / 2., y + te.height / 2.);
     cairo_set_source_u32(cairo, color);
     cairo_show_text(cairo, label);
+
+#else
+    double dx1, dy1, dx2, dy2;
+
+    cairo_set_source_u32(cairo, color);
+    switch (dir) {
+    case SPLIT_DIR_LEFT:
+        dx1 = 1.;
+        dx2 = 1.;
+        dy1 = 1.;
+        dy2 = -1.;
+        break;
+
+    case SPLIT_DIR_RIGHT:
+        dx1 = -1.;
+        dx2 = -1.;
+        dy1 = 1.;
+        dy2 = -1.;
+        break;
+
+    case SPLIT_DIR_UP:
+        dx1 = -1.;
+        dx2 = 1.;
+        dy1 = 1.;
+        dy2 = 1.;
+        break;
+
+    case SPLIT_DIR_DOWN:
+        dx1 = -1.;
+        dx2 = 1.;
+        dy1 = -1.;
+        dy2 = -1.;
+        break;
+    }
+
+    cairo_set_line_width(cairo, 2);
+    cairo_move_to(cairo, x, y);
+    cairo_line_to(cairo, x + 5 * dx1, y + 5 * dy1);
+    cairo_stroke(cairo);
+
+    cairo_move_to(cairo, x, y);
+    cairo_line_to(cairo, x + 5 * dx2, y + 5 * dy2);
+    cairo_stroke(cairo);
+#endif
 }
 
 static void split_mode_render_markers(

--- a/src/mode_split.c
+++ b/src/mode_split.c
@@ -64,44 +64,6 @@ static void split_mode_render_cursor(
 static void render_split_render_arrow(
     cairo_t *cairo, int x, int y, enum split_dir dir, uint32_t color
 ) {
-#define SIMPLE_ARROWS
-#if !defined(SIMPLE_ARROWS)
-    char *label;
-    switch (dir) {
-    case SPLIT_DIR_LEFT:
-        label = "←";
-        break;
-
-    case SPLIT_DIR_RIGHT:
-        label = "→";
-        break;
-
-    case SPLIT_DIR_UP:
-        label = "↑";
-        break;
-
-    case SPLIT_DIR_DOWN:
-        label = "↓";
-        break;
-    }
-
-    cairo_arc(cairo, x + .5, y + .5, 10, 0, 2 * M_PI);
-    cairo_set_source_u32(cairo, 0x44444455);
-    cairo_fill(cairo);
-
-    cairo_set_source_u32(cairo, color);
-    cairo_arc(cairo, x, y, 10, 0, 2 * M_PI);
-    cairo_set_line_width(cairo, 1);
-    cairo_stroke(cairo);
-
-    cairo_set_font_size(cairo, 15);
-    cairo_text_extents_t te;
-    cairo_text_extents(cairo, label, &te);
-    cairo_move_to(cairo, x - te.x_advance / 2., y + te.height / 2.);
-    cairo_set_source_u32(cairo, color);
-    cairo_show_text(cairo, label);
-
-#else
     static const struct {
         char dx1 : 2;
         char dy1 : 2;
@@ -156,7 +118,6 @@ static void render_split_render_arrow(
         y + ARROW_SIZE * arrow_points[dir].dy2 + .5
     );
     cairo_stroke(cairo);
-#endif
 }
 
 static void split_mode_render_markers(

--- a/src/mode_split.c
+++ b/src/mode_split.c
@@ -236,7 +236,7 @@ split_mode_render(struct state *state, void *mode_state, cairo_t *cairo) {
     }
 
     struct rect *area = &ms->areas[ms->current];
-    cairo_set_source_u32(cairo, 0x11111188);
+    cairo_set_source_u32(cairo, config->area_bg_color);
     cairo_rectangle(
         cairo, area->x + .5, area->y + .5, area->w - 1, area->h - 1
     );

--- a/src/mode_split.c
+++ b/src/mode_split.c
@@ -195,6 +195,24 @@ static bool split_mode_key(
         return split_mode_split(state, mode_state, SPLIT_DIR_DOWN);
     }
 
+    switch (text[0]) {
+    case 'a':
+    case 'h':
+        return split_mode_split(state, mode_state, SPLIT_DIR_LEFT);
+
+    case 'd':
+    case 'l':
+        return split_mode_split(state, mode_state, SPLIT_DIR_RIGHT);
+
+    case 'w':
+    case 'k':
+        return split_mode_split(state, mode_state, SPLIT_DIR_UP);
+
+    case 's':
+    case 'j':
+        return split_mode_split(state, mode_state, SPLIT_DIR_DOWN);
+    }
+
     return false;
 }
 

--- a/src/mode_split.c
+++ b/src/mode_split.c
@@ -206,6 +206,28 @@ static bool split_mode_key(
         return split_mode_split(state, mode_state, SPLIT_DIR_DOWN);
     }
 
+    int matched_i = find_str(state->home_row, HOME_ROW_LEN_WITH_BTN, text);
+    switch (matched_i) {
+    case HOME_ROW_LEFT_CLICK:
+        state->click = CLICK_LEFT_BTN;
+        enter_next_mode(state, ms->areas[ms->current]);
+        return false;
+
+    case HOME_ROW_RIGHT_CLICK:
+        state->click = CLICK_RIGHT_BTN;
+        enter_next_mode(state, ms->areas[ms->current]);
+        return false;
+
+    case HOME_ROW_MIDDLE_CLICK:
+        state->click = CLICK_MIDDLE_BTN;
+        enter_next_mode(state, ms->areas[ms->current]);
+        return false;
+
+    default:
+        break;
+    }
+
+    // Handle `wasd` and `hjkl` but only after home_row_keys
     switch (text[0]) {
     case 'a':
     case 'h':

--- a/src/mode_split.c
+++ b/src/mode_split.c
@@ -84,6 +84,17 @@ static void split_mode_render_cursor(
         cairo, pointer_x + (int)(config->pointer_size / 2) + .5, pointer_y + .5
     );
     cairo_stroke(cairo);
+
+    // Draw "undividable" marker, draw a red circle around the cursor
+    if (area->w <= 1 && area->h <= 1) {
+        cairo_set_source_u32(cairo, config->pointer_color);
+        cairo_arc(
+            cairo, area->x + .5, area->y + .5, config->pointer_size / 4., 0,
+            2 * M_PI
+        );
+        cairo_set_line_width(cairo, 1);
+        cairo_stroke(cairo);
+    }
 }
 
 static void

--- a/src/state.h
+++ b/src/state.h
@@ -30,7 +30,8 @@
 // pixels.
 #define BISECT_MAX_HISTORY 16
 
-// Split history of up to a resolution of 65536x65536
+// Split history of up to a resolution of 65536x65536 assuming equal number of
+// divisions each way.
 #define SPLIT_MAX_HISTORY 32
 
 #define MAX_NUM_MODES   3

--- a/src/state.h
+++ b/src/state.h
@@ -30,6 +30,9 @@
 // pixels.
 #define BISECT_MAX_HISTORY 16
 
+// Split history of up to a resolution of 65536x65536
+#define SPLIT_MAX_HISTORY 32
+
 #define MAX_NUM_MODES   3
 #define NO_MODE_ENTERED -1
 
@@ -59,6 +62,11 @@ struct floating_mode_state {
 
 struct bisect_mode_state {
     struct rect areas[BISECT_MAX_HISTORY];
+    int         current;
+};
+
+struct split_mode_state {
+    struct rect areas[SPLIT_MAX_HISTORY];
     int         current;
 };
 


### PR DESCRIPTION
This pull request implements split mode (splitting of the current area in half using arrow keys). This is exactly the same as warpd "grid" mode. Since I don't like either name, I'm open to suggestions.

Anyway, I'm sending this PR out just to get some early feedback. The feature should work, but there are still a couple of things missing:
- documentation
- key configuration

The code might look familiar since its heavily based on `mode_bisect.c`.