### PR TITLE
Fix config file loading when XDG_CONFIG_HOME is not set

### DIFF
--- a/config.example
+++ b/config.example
@@ -1,5 +1,5 @@
 # wl-kbptr can be configured with a configuration file.
-# The file location can be passed with the -C parameter.
+# The file location can be passed with the -c parameter.
 # Othewise the `$XDG_CONFIG_HOME/wl-kbptr/config` file will
 # be loaded if it exits. Below is the default configuration.
 

--- a/src/config.c
+++ b/src/config.c
@@ -483,17 +483,19 @@ static FILE *open_config_file(char *file_name) {
         return f;
     }
 
-    char *xdg_config_home = getenv("XDG_CONFIG_HOME");
+    char       *xdg_config_home     = getenv("XDG_CONFIG_HOME");
+    const char *home                = getenv("HOME");
+    size_t      config_home_buf_len = 0;
 
-    if (xdg_config_home == NULL) {
-        const char *home = getenv("HOME");
-        if (home != NULL) {
-            size_t len = strlen(home) + strlen("/.config") + 1;
-            xdg_config_home = malloc(len);
-            if (xdg_config_home) {
-                snprintf(xdg_config_home, len, "%s/.config", home);
-            }
-        }
+    if (xdg_config_home == NULL && home != NULL) {
+        config_home_buf_len = strlen(home) + sizeof("/.config");
+    }
+
+    char config_home_buf[config_home_buf_len];
+
+    if (xdg_config_home == NULL && home != NULL) {
+        snprintf(config_home_buf, config_home_buf_len, "%s/.config", home);
+        xdg_config_home = config_home_buf;
     }
 
     if (xdg_config_home != NULL) {

--- a/src/config.c
+++ b/src/config.c
@@ -312,7 +312,7 @@ static struct section_def section_defs[] = {
 
 void print_default_config() {
     puts("# wl-kbptr can be configured with a configuration file.");
-    puts("# The file location can be passed with the -C parameter.");
+    puts("# The file location can be passed with the -c parameter.");
     puts("# Othewise the `$XDG_CONFIG_HOME/wl-kbptr/config` file will");
     puts("# be loaded if it exits. Below is the default configuration.");
 
@@ -484,6 +484,18 @@ static FILE *open_config_file(char *file_name) {
     }
 
     char *xdg_config_home = getenv("XDG_CONFIG_HOME");
+
+    if (xdg_config_home == NULL) {
+        const char *home = getenv("HOME");
+        if (home != NULL) {
+            size_t len = strlen(home) + strlen("/.config") + 1;
+            xdg_config_home = malloc(len);
+            if (xdg_config_home) {
+                snprintf(xdg_config_home, len, "%s/.config", home);
+            }
+        }
+    }
+
     if (xdg_config_home != NULL) {
         int  path_len = snprintf(NULL, 0, XDG_PATH_FMT, xdg_config_home) + 1;
         char file_path[path_len];


### PR DESCRIPTION
When `XDG_CONFIG_HOME` isn't set, the default value `$HOME/.config` should be used. Without this fix, if `XDG_CONFIG_HOME` is not explicitly set, a config file at `~/.config/wl-kbptr/config` will not be loaded.

Additionally, a small related typo was corrected (`-C` to `-c`) in the documentation.