### PR TITLE
Fix Hyprland rotation not detected correctly

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -587,6 +587,11 @@ static void apply_transform(
     uint32_t *x, uint32_t *y, uint32_t *width, uint32_t *height,
     enum wl_output_transform transform
 ) {
+
+    const char *current_desktop = getenv("XDG_CURRENT_DESKTOP");
+    if (current_desktop && strcmp(current_desktop, "Hyprland") == 0) {
+        return;
+    }
     uint32_t temp;
 
     switch (transform) {

--- a/src/target_detection.cpp
+++ b/src/target_detection.cpp
@@ -179,6 +179,10 @@ static void apply_transform(
     cv::Mat &m, enum wl_output_transform transform, uint32_t &width,
     uint32_t &height
 ) {
+    const char* current_desktop = getenv("XDG_CURRENT_DESKTOP");
+    if  (current_desktop && strcmp(current_desktop, "Hyprland") == 0) {
+        return;
+    }
     cv::Mat tmp;
     bool    switch_width_height = false;
 


### PR DESCRIPTION
wl-kbptr currently doesn't handle screen rotation correctly on Hyprland, leading to incorrect pointer behavior. This is It seems like Hyprland manages output transformations differently compared to other compositors.

To address this, I added a check for the XDG_CURRENT_DESKTOP environment variable. If it equals "Hyprland", the rotation detection logic is skipped.