### PR TITLE
Fix inner label indexing in `bisect` mode

### DIFF
--- a/src/mode_bisect.c
+++ b/src/mode_bisect.c
@@ -161,7 +161,7 @@ static void division_4_or_8_render(
 
             if (inner_labels) {
                 cairo_set_source_u32(cairo, config->label_color);
-                char *label = state->home_row[i + j * sub_area_rows];
+                char *label = state->home_row[i + j * sub_area_columns];
                 cairo_text_extents_t te;
                 cairo_text_extents(cairo, label, &te);
                 cairo_move_to(


### PR DESCRIPTION
Before (with default `home_row_keys=asdfjkl;ghb`):
<img width="146" height="81" alt="image" src="https://github.com/user-attachments/assets/5776eb50-8bcb-4cfa-b042-01da3407c2ee" />
Note the repeated `d` and `f` labels.
It is purely visual; the keypress resolves to the correct sub-area.

After (also with the default home row keys):
<img width="146" height="81" alt="image" src="https://github.com/user-attachments/assets/3e88e065-38ed-41a7-9119-481c9eb38560" />
Now the label matches the keypress behavior.

By the way, thank you for this awesome tool, especially the auto-detection in floating mode!