### PR TITLE
Fix Arch Linux installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,16 @@ Here are the compositors with which it has been tested:
 
 If you are using Arch Linux, you can install the [`wl-kbptr` AUR package](https://aur.archlinux.org/packages/wl-kbptr).
 
-You can build and install the package with:
-
+Recommended way to build and install the package directly from the AUR (gets all required files):
 ```bash
-curl 'https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=wl-kbptr' -o PKGBUILD
+git clone https://aur.archlinux.org/wl-kbptr.git
+cd wl-kbptr
+makepkg -si
+```
+
+Alternatively, if you only want the `PKGBUILD`:
+```bash
+curl -L 'https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=wl-kbptr' -o PKGBUILD
 makepkg -si
 ```
 


### PR DESCRIPTION
Hi, I noticed the Arch Linux installation instructions in the README currently say:
```bash
curl 'https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=wl-kbptr' -o PKGBUILD
makepkg -si
```
This command downloads the HTML rendering of PKGBUILD (`<!DOCTYPE html> ...`) instead of the raw file. Running `makepkg` then fails with:
```
/home/user/PKGBUILD: line 1: syntax error near unexpected token `newline'
/home/user/PKGBUILD: line 1: `<!DOCTYPE html>'
```

This PR updates the command to use the correct `plain` endpoint instead of `tree` and adds -L to follow redirects (the AUR’s `plain` endpoint redirects to the current commit). It also recommends the `git clone` method as the preferred approach since it fetches all necessary files.