### PR TITLE
feat: suite of changes

### DIFF
--- a/config.example
+++ b/config.example
@@ -17,6 +17,10 @@ selectable_border_color=#040c
 label_font_family=sans-serif
 label_font_size=8 50% 100
 label_symbols=abcdefghijklmnopqrstuvwxyz
+# Set to 'true' to make labels with common prefixes (like 'a', 'aa', 'ab') adjacent to each other
+# This makes it easier to navigate to related targets, as labels are ordered lexicographically
+# Default: false (original behavior)
+prefix_adjacency=false
 
 [mode_floating]
 source=stdin

--- a/src/config.c
+++ b/src/config.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 
 /**
  * `field_color_parse` parses color field values, e.g.:
@@ -296,6 +297,26 @@ static int parse_click(void *dest, char *value) {
     return 0;
 }
 
+static int parse_bool(void *dest, char *value) {
+    bool *b = dest;
+
+    if (strcasecmp(value, "true") == 0 || strcmp(value, "1") == 0 ||
+        strcasecmp(value, "yes") == 0 || strcasecmp(value, "on") == 0) {
+        *b = true;
+    } else if (strcasecmp(value, "false") == 0 || strcmp(value, "0") == 0 ||
+               strcasecmp(value, "no") == 0 || strcasecmp(value, "off") == 0) {
+        *b = false;
+    } else {
+        LOG_ERR(
+            "Invalid boolean value '%s'. Use 'true'/'false', 'yes'/'no', '1'/'0', or 'on'/'off'.",
+            value
+        );
+        return 1;
+    }
+
+    return 0;
+}
+
 static void free_home_row_keys(void *field_value) {
     char ***home_row_keys_ptr = field_value;
     if (*home_row_keys_ptr == NULL) {
@@ -372,7 +393,8 @@ static struct section_def section_defs[] = {
         MT_FIELD(label_font_size, "8 50% 100", parse_relative_font_size, noop),
         MT_FIELD(
             label_symbols, "abcdefghijklmnopqrstuvwxyz", parse_str, free_str
-        )
+        ),
+        MT_FIELD(prefix_adjacency, "false", parse_bool, noop)
     ),
     SECTION(
         mode_floating,

--- a/src/config.h
+++ b/src/config.h
@@ -3,6 +3,7 @@
 
 #include "utils.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 
 struct general_config {
@@ -26,6 +27,7 @@ struct mode_tile_config {
     char                     *label_font_family;
     struct relative_font_size label_font_size;
     char                     *label_symbols;
+    bool                      prefix_adjacency; // Whether to make prefixes adjacent in the grid
 };
 
 enum floating_mode_source {

--- a/src/main.c
+++ b/src/main.c
@@ -623,6 +623,9 @@ static void print_result(struct state *state) {
         break;
     case CLICK_NONE:
         click = 'n';
+        break;
+    default:
+        click = 'n';  // Default to 'none' for any unexpected values
     }
 
     printf(

--- a/src/mode_bisect.c
+++ b/src/mode_bisect.c
@@ -191,33 +191,101 @@ static void division_4_or_8_render(
             );
         }
 
-        cairo_text_extents_t te;
-        cairo_text_extents(cairo, label, &te);
-        cairo_move_to(
-            cairo, area->x + (int)(area->w / 2) - (int)(te.width / 2),
-            area->y - config->label_padding
-        );
-        cairo_show_text(cairo, label);
+        // Store top label dimensions
+        cairo_text_extents_t te_top;
+        cairo_text_extents(cairo, label, &te_top);
 
         // Bottom label
+        char bottom_label[64];
         if (divide_8) {
             snprintf(
-                label, sizeof(label), "%s %s %s %s", state->home_row[4],
+                bottom_label, sizeof(bottom_label), "%s %s %s %s", state->home_row[4],
                 state->home_row[5], state->home_row[6], state->home_row[7]
             );
         } else {
             snprintf(
-                label, sizeof(label), "%s %s", state->home_row[2],
+                bottom_label, sizeof(bottom_label), "%s %s", state->home_row[2],
                 state->home_row[3]
             );
         }
 
-        cairo_text_extents(cairo, label, &te);
-        cairo_move_to(
-            cairo, area->x + (int)(area->w / 2) - (int)(te.width / 2),
-            area->y + area->h + te.height + config->label_padding
-        );
-        cairo_show_text(cairo, label);
+        // Store bottom label dimensions
+        cairo_text_extents_t te_bottom;
+        cairo_text_extents(cairo, bottom_label, &te_bottom);
+
+        // Check if we're near screen edges
+        int padding = config->label_padding;
+        bool near_top = area->y < te_top.height + 2 * padding;
+        bool near_bottom = area->y + area->h + te_bottom.height + 2 * padding > state->surface_height;
+        bool near_left = area->x < te_top.width + 2 * padding;
+        bool near_right = area->x + area->w + te_bottom.width + 2 * padding > state->current_output->width;
+
+        if (near_top && !near_bottom) {
+            // Both labels below the area
+            cairo_move_to(
+                cairo, area->x + (int)(area->w / 2) - (int)(te_top.width / 2),
+                area->y + area->h + padding + te_top.height
+            );
+            cairo_show_text(cairo, label);
+
+            cairo_move_to(
+                cairo, area->x + (int)(area->w / 2) - (int)(te_bottom.width / 2),
+                area->y + area->h + te_top.height + padding * 2 + te_bottom.height
+            );
+            cairo_show_text(cairo, bottom_label);
+        } else if (!near_top && near_bottom) {
+            // Both labels above the area
+            cairo_move_to(
+                cairo, area->x + (int)(area->w / 2) - (int)(te_bottom.width / 2),
+                area->y - padding
+            );
+            cairo_show_text(cairo, bottom_label);
+
+            cairo_move_to(
+                cairo, area->x + (int)(area->w / 2) - (int)(te_top.width / 2),
+                area->y - padding - te_bottom.height - padding
+            );
+            cairo_show_text(cairo, label);
+        } else if (near_left && !near_right) {
+            // Area is near left edge, position labels to the right
+            cairo_move_to(
+                cairo, area->x + area->w + padding,
+                area->y - padding
+            );
+            cairo_show_text(cairo, label);
+
+            cairo_move_to(
+                cairo, area->x + area->w + padding,
+                area->y + padding + te_top.height
+            );
+            cairo_show_text(cairo, bottom_label);
+        } else if (!near_left && near_right) {
+            // Area is near right edge, position labels to the left
+            cairo_move_to(
+                cairo, area->x - padding - te_top.width,
+                area->y - padding
+            );
+            cairo_show_text(cairo, label);
+
+            cairo_move_to(
+                cairo, area->x - padding - te_bottom.width,
+                area->y + padding + te_top.height
+            );
+            cairo_show_text(cairo, bottom_label);
+        } else {
+            // Standard positioning - top label above, bottom label below
+            cairo_move_to(
+                cairo, area->x + (int)(area->w / 2) - (int)(te_top.width / 2),
+                area->y - padding
+            );
+            cairo_show_text(cairo, label);
+
+            cairo_move_to(
+                cairo, area->x + (int)(area->w / 2) - (int)(te_bottom.width / 2),
+                area->y + area->h + te_bottom.height + padding
+            );
+            cairo_show_text(cairo, bottom_label);
+        }
     }
 }
 

--- a/src/mode_tile.c
+++ b/src/mode_tile.c
@@ -6,6 +6,7 @@
 #include "utils_cairo.h"
 
 #include <cairo.h>
+#include <math.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -71,8 +72,10 @@ void tile_mode_reenter(struct state *state, void *mode_state) {
     tile_mode_back(ms);
 }
 
+
 static struct rect
 idx_to_rect(struct tile_mode_state *mode_state, int idx, int x_off, int y_off) {
+    // Get the grid position based on index
     int row = idx / mode_state->sub_area_columns;
     int column = idx % mode_state->sub_area_columns;
 
@@ -88,10 +91,82 @@ idx_to_rect(struct tile_mode_state *mode_state, int idx, int x_off, int y_off) {
     };
 }
 
+static int *create_indices(struct tile_mode_state *ms, bool adjacent) {
+    const int total_tiles = ms->sub_area_rows * ms->sub_area_columns;
+    int *indices = malloc(total_tiles * sizeof(int));
+
+    // Initialize with sequential indices
+    for (int i = 0; i < total_tiles; i++) {
+        indices[i] = i;
+    }
+
+    // If prefix adjacency is not enabled, just return sequential indices
+    if (!adjacent) {
+        return indices;
+    }
+
+    // For prefix adjacency, sort indices lexicographically by their labels
+    label_selection_t *temp_label = label_selection_new(ms->label_symbols, total_tiles);
+    int label_str_max_len = label_selection_str_max_len(temp_label) + 1;
+    char **label_strs = malloc(total_tiles * sizeof(char *));
+
+    // Generate all label strings
+    for (int i = 0; i < total_tiles; i++) {
+        label_strs[i] = malloc(label_str_max_len);
+        label_selection_set_from_idx(temp_label, i);
+        label_selection_str(temp_label, label_strs[i]);
+    }
+
+    // Simple insertion sort by label string
+    for (int i = 0; i < total_tiles; i++) {
+        for (int j = i + 1; j < total_tiles; j++) {
+            if (strcmp(label_strs[indices[i]], label_strs[indices[j]]) > 0) {
+                int temp = indices[i];
+                indices[i] = indices[j];
+                indices[j] = temp;
+            }
+        }
+    }
+
+    // Clean up
+    for (int i = 0; i < total_tiles; i++) {
+        free(label_strs[i]);
+    }
+    free(label_strs);
+    label_selection_free(temp_label);
+
+    return indices;
+}
+
+// Finds the grid index corresponding to a label selection
+static int find_grid_index(struct tile_mode_state *ms, int label_idx, bool use_adjacency) {
+    // If adjacency isn't enabled, the grid index is the same as the label index
+    if (!use_adjacency) {
+        return label_idx;
+    }
+
+    // Create the ordered indices (same as used in rendering)
+    int *indices = create_indices(ms, true);
+    const int total_tiles = ms->sub_area_rows * ms->sub_area_columns;
+
+    // Search for the position where our label_idx appears in the indices array
+    int grid_idx = -1;
+    for (int i = 0; i < total_tiles; i++) {
+        if (indices[i] == label_idx) {
+            grid_idx = i;
+            break;
+        }
+    }
+
+    free(indices);
+    return grid_idx;
+}
+
 static bool tile_mode_key(
     struct state *state, void *mode_state, xkb_keysym_t keysym, char *text
 ) {
     struct tile_mode_state *ms = mode_state;
+    struct mode_tile_config *config = &state->config.mode_tile;
 
     switch (keysym) {
     case XKB_KEY_BackSpace:
@@ -109,10 +184,14 @@ static bool tile_mode_key(
 
         label_selection_append(ms->label_selection, symbol_idx);
 
-        int idx = label_selection_to_idx(ms->label_selection);
-        if (idx >= 0) {
+        int label_idx = label_selection_to_idx(ms->label_selection);
+        if (label_idx >= 0) {
+            // Convert the label index to the corresponding grid position
+            int grid_idx = find_grid_index(ms, label_idx, config->prefix_adjacency);
+
+            // Use the grid index to determine the rectangle
             enter_next_mode(
-                state, idx_to_rect(ms, idx, ms->area.x, ms->area.y)
+                state, idx_to_rect(ms, grid_idx, ms->area.x, ms->area.y)
             );
         }
         return true;
@@ -143,17 +222,35 @@ void tile_mode_render(struct state *state, void *mode_state, cairo_t *cairo) {
     cairo_set_line_width(cairo, 1);
     cairo_stroke(cairo);
 
-    label_selection_t *curr_label = label_selection_new(
-        ms->label_symbols, ms->sub_area_columns * ms->sub_area_rows
-    );
-    label_selection_set_from_idx(curr_label, 0);
+    // Create indices for rendering based on configuration
+    const int total_tiles = ms->sub_area_rows * ms->sub_area_columns;
+    int *indices = create_indices(ms, config->prefix_adjacency);
 
-    int  label_str_max_len = label_selection_str_max_len(curr_label) + 1;
+    // Create a temporary label for rendering
+    label_selection_t *curr_label = label_selection_new(
+        ms->label_symbols, total_tiles
+    );
+
+    int label_str_max_len = label_selection_str_max_len(curr_label) + 1;
     char label_selected_str[label_str_max_len];
     char label_unselected_str[label_str_max_len];
 
+    // Render tiles in grid order with the appropriate indices
     for (int j = 0; j < ms->sub_area_rows; j++) {
         for (int i = 0; i < ms->sub_area_columns; i++) {
+            const int grid_idx = j * ms->sub_area_columns + i;
+
+            // Skip if we're out of bounds
+            if (grid_idx >= total_tiles) {
+                continue;
+            }
+
+            // Get the index for this grid position
+            const int idx = indices[grid_idx];
+
+            // Set the label for this tile using the appropriate index
+            label_selection_set_from_idx(curr_label, idx);
+
             const int x =
                 i * ms->sub_area_width + min(i, ms->sub_area_width_off);
             const int w =
@@ -202,11 +299,10 @@ void tile_mode_render(struct state *state, void *mode_state, cairo_t *cairo) {
                 cairo_set_source_u32(cairo, config->label_color);
                 cairo_show_text(cairo, label_unselected_str);
             }
-
-            label_selection_incr(curr_label);
         }
     }
 
+    free(indices);
     label_selection_free(curr_label);
     cairo_translate(cairo, -ms->area.x, -ms->area.y);
 }

--- a/src/mode_tile.c
+++ b/src/mode_tile.c
@@ -73,8 +73,8 @@ void tile_mode_reenter(struct state *state, void *mode_state) {
 
 static struct rect
 idx_to_rect(struct tile_mode_state *mode_state, int idx, int x_off, int y_off) {
-    int column = idx / mode_state->sub_area_rows;
-    int row    = idx % mode_state->sub_area_rows;
+    int row = idx / mode_state->sub_area_columns;
+    int column = idx % mode_state->sub_area_columns;
 
     return (struct rect){
         .x = column * mode_state->sub_area_width +
@@ -152,8 +152,8 @@ void tile_mode_render(struct state *state, void *mode_state, cairo_t *cairo) {
     char label_selected_str[label_str_max_len];
     char label_unselected_str[label_str_max_len];
 
-    for (int i = 0; i < ms->sub_area_columns; i++) {
-        for (int j = 0; j < ms->sub_area_rows; j++) {
+    for (int j = 0; j < ms->sub_area_rows; j++) {
+        for (int i = 0; i < ms->sub_area_columns; i++) {
             const int x =
                 i * ms->sub_area_width + min(i, ms->sub_area_width_off);
             const int w =


### PR DESCRIPTION
# Overview

First: my apologies/caveat since this is one of my first PRs almost completely relying on LLM-generated changes.  I made sure to preserve that information in the commit messages. However, I've been testing this branch lightly over the last 12h and I'd like to consider the ideas in the commits for review, even if the exact change set is undesirable for any number of reasons. Also, each of these commits is notionally independent, so I've done some work to extract each into its own branch off of `main` (`0.4.1`). But, 2 of the 4 commits on this branch are interdependent (they affect the same file in dependent ways) so `cherry-pick`ing wasn't clean when generating all the associated "one-commit branches. Please note that the entirety of the human interactions (prose) in this PR (including this description) will be generated manually by me.

I only ask maintainers to consider the pain points and ideas, below. Given that I haven't reviewed the generated code, it may introduce new issues which I haven't considered. I'll outline the goal of each commit, below. If this entire PR branch as-is is accepted, then there's no need to consider the commits in isolation on their own branches. If certain changes need more review then we can drop any/all commits, here, and open separate PRs as-needed on a case-by-case basis.

Please note that I have not defined a `wl-kbptr` configuration file. So, I'm using the default application logic/configuration according to `wl-kbptr`'s user documentation.

## Commit 1 (UX fix)
1. On at least one of my displays, I'm seeing duplicate labels in bisect mode (after tile mode). I don't see this on all displays, though. Please see the below screencasts for the problem and after applying this commit/patch.

### 0.4.1
https://github.com/user-attachments/assets/223955f6-04b7-4c3c-8300-97aabff19177
### With edfd6cd193f75981938b2959f6b13c6348737dbf
https://github.com/user-attachments/assets/d6d980e4-ce6a-40fd-9f5c-80470581cb5b

## Commit 2 (UI fix)
I'm finding that on at least one of my displays, the bisect labels run off the screen for those "rectangles" on the edge of the screen. Please see the screencasts below documenting the problem and the "fix". I don't love how the labels aren't positioned in the same row/column as the rectangles, exactly. But, the spirit of this change is correct: labels are always visible. I also saw that labels would be inconsistently embedded within squares at a given "level". So, toward the top of my screen, the bisect rectangles may have the text _within_ the corresponding square, because it was deemed small enough to fit, but then at the bottom of my screen, the labels would surround the rectangle (not be placed within the square) even though the square and font size were the same - only the rectangle's position on the display was different. So, this commit also tries to make this behavior consistent.

### 0.4.1
https://github.com/user-attachments/assets/ad9ad4cf-9491-4766-a8f4-7c9d70e2d97f

### 589f2abb41bdc2e8793cf271dcc1765326c342a1
https://github.com/user-attachments/assets/7e881742-67e8-4588-bcda-938a4f08dd3b

## Commit 3 (compilation fix)
This just fixes a compiler warning:
```
[9/11] Compiling C object wl-kbptr.p/src_main.c.o
In function ‘print_result’,
    inlined from ‘main’ at ../src/main.c:921:9:
../src/main.c:628:5: warning: ‘click’ may be used uninitialized [-Wmaybe-uninitialized]
  628 |     printf(
      |     ^~~~~~~
  629 |         "%dx%d+%d+%d +%d+%d %c\n", state->result.w, state->result.h,
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  630 |         state->result.x, state->result.y, state->current_output->x,
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  631 |         state->current_output->y, click
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  632 |     );
      |     ~
../src/main.c: In function ‘main’:
../src/main.c:613:10: note: ‘click’ was declared here
  613 |     char click;
      |          ^~~~~
```

## Commit 4 (feature)
I love this change/feature less than what I first created it, so no stress to discard. This change basically allows users to opt in to (`prefix_adjacency=[false|true]` in their configuration file) a tile mode behavior where selecting `a` for something like `al` will ensure that `ak` and `am` are adjacent to `al`. If this commit is placed on `0.4.1` (instead of on top of `edfd6cd193f75981938b2959f6b13c6348737dbf` (commit #1)) then the adjacency will be vertical instead of horizontal, since that commit changes the layout ordering of tiles. Please see the screencast for what this looks like.

### 0.4.1
https://github.com/user-attachments/assets/8e25ec88-247f-4562-9914-e85277e4e0d1

### 8b9903579532aeb4fcf477023c4e12b685f3a73a
https://github.com/user-attachments/assets/d456bf0b-344d-43fe-930e-28967363c871
