### PR TITLE
Add all-outputs mode for #78

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,16 +239,12 @@ all_outputs=true
 
 - One overlay surface is created per output, each covering its respective monitor.
 - The first surface gets exclusive keyboard focus; the compositor routes all key events there regardless of which monitor the cursor is on.
-- All surfaces share a single label namespace spanning the global bounding box of all outputs.
+- Each monitor is treated as an independent **region** with its own rows×cols grid; labels are indexed continuously across all regions.
 - After you type a label, the cursor moves to the correct output automatically.
 
 ### Cell density
 
-Cell size is computed from the **average logical monitor area** rather than the full bounding box. This keeps cell density consistent with single-output mode — each monitor gets roughly the same number of cells as it would on its own. With multiple monitors, most labels will require more keystrokes (3 with 3 monitors) since the total number of cells scales with the number of outputs.
-
-### Dead zones
-
-If your monitors are not perfectly aligned (e.g. one is above or below the others), there may be empty regions in the bounding box not covered by any output. Cells whose centre falls in such a gap are skipped entirely — no label is assigned to them. This keeps the full label budget for reachable cells, producing more 2-letter codes on setups with unaligned monitors. If a result coordinate somehow falls in a gap, it snaps to the nearest monitor boundary.
+Cell size is computed from the **average logical monitor area**, keeping density consistent with single-output mode — each monitor gets roughly the same number of cells as it would on its own. With multiple monitors the total label count scales with the number of outputs, so labels may require more keystrokes (e.g. 3 characters with 3 monitors).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,40 @@ submap = reset
 bind=$mainMod,g,exec,hyprctl keyword cursor:inactive_timeout 0; hyprctl keyword cursor:hide_on_key_press false; hyprctl dispatch submap cursor
 ```
 
+## Multi-monitor support
+
+By default, `wl-kbptr` shows its overlay only on the currently focused output. The `--all-outputs` / `-A` flag spans the overlay across all connected outputs simultaneously, so you don't need to focus the right display before invoking it.
+
+> **Note:** Multi-monitor mode is currently implemented for **tile mode only**. Floating mode multi-monitor support is not yet available.
+
+### Usage
+
+```bash
+wl-kbptr -A -o modes=tile,click
+```
+
+Or enable it permanently in your configuration file:
+
+```ini
+[general]
+all_outputs=true
+```
+
+### How it works
+
+- One overlay surface is created per output, each covering its respective monitor.
+- The first surface gets exclusive keyboard focus; the compositor routes all key events there regardless of which monitor the cursor is on.
+- All surfaces share a single label namespace spanning the global bounding box of all outputs.
+- After you type a label, the cursor moves to the correct output automatically.
+
+### Cell density
+
+Cell size is computed from the **average logical monitor area** rather than the full bounding box. This keeps cell density consistent with single-output mode — each monitor gets roughly the same number of cells as it would on its own. With multiple monitors, most labels will require more keystrokes (3 with 3 monitors) since the total number of cells scales with the number of outputs.
+
+### Dead zones
+
+If your monitors are not perfectly aligned (e.g. one is above or below the others), there may be empty regions in the bounding box not covered by any output. Cells whose centre falls in such a gap snap to the nearest monitor boundary rather than moving the cursor off-screen.
+
 ## Configuration
 
 `wl-kbptr` can be configured with a configuration file. See [`config.example`](./config.example) for an example and run `wl-kbptr --help-config` for help.

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Cell size is computed from the **average logical monitor area** rather than the 
 
 ### Dead zones
 
-If your monitors are not perfectly aligned (e.g. one is above or below the others), there may be empty regions in the bounding box not covered by any output. Cells whose centre falls in such a gap snap to the nearest monitor boundary rather than moving the cursor off-screen.
+If your monitors are not perfectly aligned (e.g. one is above or below the others), there may be empty regions in the bounding box not covered by any output. Cells whose centre falls in such a gap are skipped entirely — no label is assigned to them. This keeps the full label budget for reachable cells, producing more 2-letter codes on setups with unaligned monitors. If a result coordinate somehow falls in a gap, it snaps to the nearest monitor boundary.
 
 ## Configuration
 

--- a/config.example
+++ b/config.example
@@ -7,6 +7,9 @@
 home_row_keys=
 modes=tile,bisect
 cancellation_status_code=0
+# Span the overlay across all connected outputs simultaneously (tile mode only).
+# Equivalent to the -A / --all-outputs command-line flag.
+all_outputs=false
 
 [mode_tile]
 label_color=#fffd

--- a/src/config.c
+++ b/src/config.c
@@ -85,6 +85,21 @@ static int parse_double(void *dest, char *value) {
     return 0;
 }
 
+static int parse_bool(void *dest, char *value) {
+    bool *out = dest;
+    if (strcmp(value, "true") == 0 || strcmp(value, "1") == 0) {
+        *out = true;
+    } else if (strcmp(value, "false") == 0 || strcmp(value, "0") == 0) {
+        *out = false;
+    } else {
+        LOG_ERR(
+            "Invalid boolean value '%s'. Should be 'true' or 'false'.", value
+        );
+        return 1;
+    }
+    return 0;
+}
+
 static int parse_uint8(void *dest, char *value) {
     int decoded = atoi(value);
     if (decoded < 0 || decoded >= 256) {
@@ -360,7 +375,8 @@ static struct section_def section_defs[] = {
         general,
         G_FIELD(home_row_keys, "", parse_home_row_keys, free_home_row_keys),
         G_FIELD(modes, "tile,bisect", parse_str, free_str),
-        G_FIELD(cancellation_status_code, "0", parse_uint8, noop)
+        G_FIELD(cancellation_status_code, "0", parse_uint8, noop),
+        G_FIELD(all_outputs, "false", parse_bool, noop)
     ),
     SECTION(
         mode_tile, MT_FIELD(label_color, "#fffd", parse_color, noop),

--- a/src/config.h
+++ b/src/config.h
@@ -3,12 +3,14 @@
 
 #include "utils.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 
 struct general_config {
     char  **home_row_keys;
     char   *modes;
     uint8_t cancellation_status_code;
+    bool    all_outputs;
 };
 
 struct relative_font_size {

--- a/src/main.c
+++ b/src/main.c
@@ -593,15 +593,15 @@ static void handle_layer_surface_configure(
     overlay->height = height;
     zwlr_layer_surface_v1_ack_configure(layer_surface, serial);
 
+    bool was_configured = overlay->configured;
+    overlay->configured = true;
+
     if (overlay->output != NULL) {
-        overlay->configured = true;
         enter_first_mode(state);
-    } else if (!overlay->configured) {
+    } else if (!was_configured) {
         // Output not yet known; send a transparent frame to get surface.enter.
         send_transparent_frame_to_overlay(overlay);
     }
-
-    overlay->configured = true;
 }
 
 static void handle_layer_surface_closed(
@@ -706,8 +706,8 @@ static void resolve_result_output(struct state *state) {
         }
     }
 
-    // The result centre is in a dead zone (gap between monitors).  Find the
-    // nearest output and snap the centre to its closest edge.
+    // Result centre is not on any output (e.g. a mode that doesn't yet handle
+    // per-region placement).  Find the nearest output and snap to its edge.
     struct output *best      = NULL;
     int32_t        best_dist = INT32_MAX;
     wl_list_for_each (output, &state->outputs, link) {
@@ -877,7 +877,7 @@ int main(int argc, char **argv) {
     };
 
     int    num_cli_configs      = 0;
-    char **cli_configs          = malloc(10 * sizeof(char *));
+    char **cli_configs          = malloc(10 * sizeof(char*));
     int    cli_configs_len      = 10;
     int    option_char          = 0;
     int    option_index         = 0;
@@ -913,7 +913,7 @@ int main(int argc, char **argv) {
             if (num_cli_configs >= cli_configs_len) {
                 cli_configs_len += 10;
                 cli_configs =
-                    realloc(cli_configs, cli_configs_len * sizeof(char *));
+                    realloc(cli_configs, cli_configs_len * sizeof(char*));
             }
             cli_configs[num_cli_configs++] = optarg;
             break;

--- a/src/mode_tile.c
+++ b/src/mode_tile.c
@@ -14,11 +14,8 @@
 #define MIN_SUB_AREA_SIZE (25 * 50)
 
 void *tile_mode_enter(struct state *state, struct rect area) {
-    struct tile_mode_state *ms = malloc(sizeof(*ms));
+    struct tile_mode_state *ms = calloc(1, sizeof(*ms));
     ms->area                   = area;
-    ms->regions                = NULL;
-    ms->num_regions            = 0;
-    ms->cell_idx_map           = NULL;
 
     const int max_num_sub_areas = 26 * 26;
 
@@ -203,10 +200,8 @@ static bool tile_mode_key(
                     break;
                 }
             } else {
-                int cell_idx =
-                    ms->cell_idx_map ? ms->cell_idx_map[label_idx] : label_idx;
                 enter_next_mode(
-                    state, idx_to_rect(ms, cell_idx, ms->area.x, ms->area.y)
+                    state, idx_to_rect(ms, label_idx, ms->area.x, ms->area.y)
                 );
             }
         }
@@ -216,9 +211,8 @@ static bool tile_mode_key(
     return false;
 }
 
-// Render one selectable cell at position (x, y) with size (w, h) in the
-// current cairo coordinate space.  curr_label is the label for this cell;
-// ms->label_selection holds the user's current input.
+// Render one selectable cell at position (x, y) with size (w, h).
+// curr_label is the label for this cell; selection is the current user input.
 static void render_cell(
     struct mode_tile_config *config, cairo_t *cairo,
     label_selection_t *curr_label, label_selection_t *selection,
@@ -334,9 +328,8 @@ void tile_mode_render(struct state *state, void *mode_state, cairo_t *cairo) {
         label_selection_set_from_idx(curr_label, 0);
 
         for (int li = 0; li < num_labels; li++) {
-            int ci     = ms->cell_idx_map ? ms->cell_idx_map[li] : li;
-            int column = ci / ms->sub_area_rows;
-            int row    = ci % ms->sub_area_rows;
+            int column = li / ms->sub_area_rows;
+            int row    = li % ms->sub_area_rows;
 
             int x = column * ms->sub_area_width +
                     min(column, ms->sub_area_width_off);
@@ -366,7 +359,6 @@ void tile_mode_state_free(void *mode_state) {
     label_selection_free(ms->label_selection);
     label_symbols_free(ms->label_symbols);
     free(ms->regions);
-    free(ms->cell_idx_map);
     free(ms);
 }
 

--- a/src/state.h
+++ b/src/state.h
@@ -50,6 +50,10 @@ struct tile_mode_state {
     int sub_area_height;
     int sub_area_height_off;
 
+    // Maps label index -> linear cell index. NULL when every cell is valid
+    // (single-output mode or no dead zones).
+    int *cell_idx_map;
+
     label_selection_t *label_selection;
     label_symbols_t   *label_symbols;
 

--- a/src/state.h
+++ b/src/state.h
@@ -66,7 +66,6 @@ struct tile_mode_state {
     int sub_area_columns;
     int sub_area_height;
     int sub_area_height_off;
-    int *cell_idx_map;
 
     label_selection_t *label_selection;
     label_symbols_t   *label_symbols;
@@ -118,12 +117,12 @@ struct state;
 struct overlay_surface {
     struct wl_list link; // type: struct overlay_surface
 
-    struct wl_surface            *wl_surface;
-    struct wl_callback           *wl_surface_callback;
-    struct zwlr_layer_surface_v1 *wl_layer_surface;
-    struct wp_viewport           *wp_viewport;
+    struct wl_surface             *wl_surface;
+    struct wl_callback            *wl_surface_callback;
+    struct zwlr_layer_surface_v1  *wl_layer_surface;
+    struct wp_viewport            *wp_viewport;
     struct wp_fractional_scale_v1 *fractional_scale;
-    struct surface_buffer_pool    surface_buffer_pool;
+    struct surface_buffer_pool     surface_buffer_pool;
 
     uint32_t width;
     uint32_t height;

--- a/src/state.h
+++ b/src/state.h
@@ -39,19 +39,33 @@
 
 struct mode_interface;
 
-struct tile_mode_state {
-    struct rect area;
+// One selectable region per monitor in all-outputs mode.
+struct tile_region {
+    struct rect area;       // position and size in global coordinates
+    int         rows;
+    int         cols;
+    int         cell_w;      // base cell width
+    int         cell_w_off;  // columns that get 1 extra px (remainder distribution)
+    int         cell_h;      // base cell height
+    int         cell_h_off;  // rows that get 1 extra px
+    int         label_offset; // index of first label in this region
+    int         num_labels;   // rows * cols
+};
 
+struct tile_mode_state {
+    // Region-based multi-output fields (set when all_outputs is true).
+    // NULL in single-output mode.
+    struct tile_region *regions;
+    int                 num_regions;
+
+    // Single-output fields (used when regions == NULL).
+    struct rect area;
     int sub_area_rows;
     int sub_area_width;
     int sub_area_width_off;
-
     int sub_area_columns;
     int sub_area_height;
     int sub_area_height_off;
-
-    // Maps label index -> linear cell index. NULL when every cell is valid
-    // (single-output mode or no dead zones).
     int *cell_idx_map;
 
     label_selection_t *label_selection;


### PR DESCRIPTION
This implements a multi-monitor simultaneous mode. `wl-kbptr --all-outputs -o modes=tile,click` now shows a tiled grid across all monitors, allowing user to select a tile across multiple displays.

Currently works in my testing in tile mode. If you like it I can look at adding floating mode as well. It's not obvious to me how this would work in bisect/split modes so my inclination is to leave those out.