### PR TITLE
Exclusive regions implementation for #78, plus floating mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,16 +239,12 @@ all_outputs=true
 
 - One overlay surface is created per output, each covering its respective monitor.
 - The first surface gets exclusive keyboard focus; the compositor routes all key events there regardless of which monitor the cursor is on.
-- All surfaces share a single label namespace spanning the global bounding box of all outputs.
+- Each monitor is treated as an independent **region** with its own rows×cols grid; labels are indexed continuously across all regions.
 - After you type a label, the cursor moves to the correct output automatically.
 
 ### Cell density
 
-Cell size is computed from the **average logical monitor area** rather than the full bounding box. This keeps cell density consistent with single-output mode — each monitor gets roughly the same number of cells as it would on its own. With multiple monitors, most labels will require more keystrokes (3 with 3 monitors) since the total number of cells scales with the number of outputs.
-
-### Dead zones
-
-If your monitors are not perfectly aligned (e.g. one is above or below the others), there may be empty regions in the bounding box not covered by any output. Cells whose centre falls in such a gap are skipped entirely — no label is assigned to them. This keeps the full label budget for reachable cells, producing more 2-letter codes on setups with unaligned monitors. If a result coordinate somehow falls in a gap, it snaps to the nearest monitor boundary.
+Cell size is computed from the **average logical monitor area**, keeping density consistent with single-output mode — each monitor gets roughly the same number of cells as it would on its own. With multiple monitors the total label count scales with the number of outputs, so labels may require more keystrokes (e.g. 3 characters with 3 monitors).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -247,8 +247,8 @@ This exclusive-region approach handles arbitrary overlap topologies correctly:
 | Layout | Behaviour |
 | ------ | --------- |
 | Side-by-side / stacked (no overlap) | One region per monitor, as expected. |
-| Corner overlap | Each monitor's exclusive area is split into up to 4 rectangles; the shared corner belongs to whichever monitor is listed first by the compositor. |
-| Landscape + portrait overlap | The portrait monitor's cells cover only the rows that extend below the landscape monitor; the landscape monitor's cells cover the columns outside the portrait monitor's width. |
+| Corner overlap | The first monitor keeps its full area; the second monitor's exclusive area is 2 strips (the non-overlapping edges). The shared corner belongs to the first monitor. |
+| Landscape + portrait overlap | The first-listed monitor keeps its full area. If landscape is first, the portrait monitor covers only the strip extending beyond the landscape area. If portrait is first, landscape gets left/right columns beside the portrait. |
 | Full mirror (same logical position) | The second monitor has no exclusive area and receives no labels. Its overlay surface shows only the background tint. |
 
 ### Cell density

--- a/README.md
+++ b/README.md
@@ -216,6 +216,40 @@ submap = reset
 bind=$mainMod,g,exec,hyprctl keyword cursor:inactive_timeout 0; hyprctl keyword cursor:hide_on_key_press false; hyprctl dispatch submap cursor
 ```
 
+## Multi-monitor support
+
+By default, `wl-kbptr` shows its overlay only on the currently focused output. The `--all-outputs` / `-A` flag spans the overlay across all connected outputs simultaneously, so you don't need to focus the right display before invoking it.
+
+> **Note:** Multi-monitor mode is currently implemented for **tile mode only**. Floating mode multi-monitor support is not yet available.
+
+### Usage
+
+```bash
+wl-kbptr -A -o modes=tile,click
+```
+
+Or enable it permanently in your configuration file:
+
+```ini
+[general]
+all_outputs=true
+```
+
+### How it works
+
+- One overlay surface is created per output, each covering its respective monitor.
+- The first surface gets exclusive keyboard focus; the compositor routes all key events there regardless of which monitor the cursor is on.
+- All surfaces share a single label namespace spanning the global bounding box of all outputs.
+- After you type a label, the cursor moves to the correct output automatically.
+
+### Cell density
+
+Cell size is computed from the **average logical monitor area** rather than the full bounding box. This keeps cell density consistent with single-output mode — each monitor gets roughly the same number of cells as it would on its own. With multiple monitors, most labels will require more keystrokes (3 with 3 monitors) since the total number of cells scales with the number of outputs.
+
+### Dead zones
+
+If your monitors are not perfectly aligned (e.g. one is above or below the others), there may be empty regions in the bounding box not covered by any output. Cells whose centre falls in such a gap snap to the nearest monitor boundary rather than moving the cursor off-screen.
+
 ## Configuration
 
 `wl-kbptr` can be configured with a configuration file. See [`config.example`](./config.example) for an example and run `wl-kbptr --help-config` for help.

--- a/README.md
+++ b/README.md
@@ -239,8 +239,17 @@ all_outputs=true
 
 - One overlay surface is created per output, each covering its respective monitor.
 - The first surface gets exclusive keyboard focus; the compositor routes all key events there regardless of which monitor the cursor is on.
-- Each monitor is treated as an independent **region** with its own rows×cols grid; labels are indexed continuously across all regions.
+- Each monitor is assigned its **exclusive pixels** — its full logical bounds minus any area that overlaps with a previously processed monitor. Labels are indexed continuously across all resulting regions.
 - After you type a label, the cursor moves to the correct output automatically.
+
+This exclusive-region approach handles arbitrary overlap topologies correctly:
+
+| Layout | Behaviour |
+| ------ | --------- |
+| Side-by-side / stacked (no overlap) | One region per monitor, as expected. |
+| Corner overlap | Each monitor's exclusive area is split into up to 4 rectangles; the shared corner belongs to whichever monitor is listed first by the compositor. |
+| Landscape + portrait overlap | The portrait monitor's cells cover only the rows that extend below the landscape monitor; the landscape monitor's cells cover the columns outside the portrait monitor's width. |
+| Full mirror (same logical position) | The second monitor has no exclusive area and receives no labels. Its overlay surface shows only the background tint. |
 
 ### Cell density
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Cell size is computed from the **average logical monitor area** rather than the 
 
 ### Dead zones
 
-If your monitors are not perfectly aligned (e.g. one is above or below the others), there may be empty regions in the bounding box not covered by any output. Cells whose centre falls in such a gap snap to the nearest monitor boundary rather than moving the cursor off-screen.
+If your monitors are not perfectly aligned (e.g. one is above or below the others), there may be empty regions in the bounding box not covered by any output. Cells whose centre falls in such a gap are skipped entirely — no label is assigned to them. This keeps the full label budget for reachable cells, producing more 2-letter codes on setups with unaligned monitors. If a result coordinate somehow falls in a gap, it snaps to the nearest monitor boundary.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ bind=$mainMod,g,exec,hyprctl keyword cursor:inactive_timeout 0; hyprctl keyword 
 
 By default, `wl-kbptr` shows its overlay only on the currently focused output. The `--all-outputs` / `-A` flag spans the overlay across all connected outputs simultaneously, so you don't need to focus the right display before invoking it.
 
-> **Note:** Multi-monitor mode is currently implemented for **tile mode only**. Floating mode multi-monitor support is not yet available.
+> **Note:** Multi-monitor mode is implemented for **tile mode** and **floating mode**. For floating mode with `mode_floating.source=detect`, targets are detected on each output independently and combined. For floating mode with stdin input, pass areas in global coordinates.
 
 ### Usage
 

--- a/config.example
+++ b/config.example
@@ -7,7 +7,7 @@
 home_row_keys=
 modes=tile,bisect
 cancellation_status_code=0
-# Span the overlay across all connected outputs simultaneously (tile mode only).
+# Span the overlay across all connected outputs simultaneously (tile and floating modes).
 # Equivalent to the -A / --all-outputs command-line flag.
 all_outputs=false
 

--- a/config.example
+++ b/config.example
@@ -7,6 +7,9 @@
 home_row_keys=
 modes=tile,bisect
 cancellation_status_code=0
+# Span the overlay across all connected outputs simultaneously (tile mode only).
+# Equivalent to the -A / --all-outputs command-line flag.
+all_outputs=false
 
 [mode_tile]
 label_color=#fffd

--- a/src/config.c
+++ b/src/config.c
@@ -85,6 +85,21 @@ static int parse_double(void *dest, char *value) {
     return 0;
 }
 
+static int parse_bool(void *dest, char *value) {
+    bool *out = dest;
+    if (strcmp(value, "true") == 0 || strcmp(value, "1") == 0) {
+        *out = true;
+    } else if (strcmp(value, "false") == 0 || strcmp(value, "0") == 0) {
+        *out = false;
+    } else {
+        LOG_ERR(
+            "Invalid boolean value '%s'. Should be 'true' or 'false'.", value
+        );
+        return 1;
+    }
+    return 0;
+}
+
 static int parse_uint8(void *dest, char *value) {
     int decoded = atoi(value);
     if (decoded < 0 || decoded >= 256) {
@@ -360,7 +375,8 @@ static struct section_def section_defs[] = {
         general,
         G_FIELD(home_row_keys, "", parse_home_row_keys, free_home_row_keys),
         G_FIELD(modes, "tile,bisect", parse_str, free_str),
-        G_FIELD(cancellation_status_code, "0", parse_uint8, noop)
+        G_FIELD(cancellation_status_code, "0", parse_uint8, noop),
+        G_FIELD(all_outputs, "false", parse_bool, noop)
     ),
     SECTION(
         mode_tile, MT_FIELD(label_color, "#fffd", parse_color, noop),

--- a/src/config.h
+++ b/src/config.h
@@ -3,12 +3,14 @@
 
 #include "utils.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 
 struct general_config {
     char  **home_row_keys;
     char   *modes;
     uint8_t cancellation_status_code;
+    bool    all_outputs;
 };
 
 struct relative_font_size {

--- a/src/main.c
+++ b/src/main.c
@@ -593,15 +593,15 @@ static void handle_layer_surface_configure(
     overlay->height = height;
     zwlr_layer_surface_v1_ack_configure(layer_surface, serial);
 
+    bool was_configured = overlay->configured;
+    overlay->configured = true;
+
     if (overlay->output != NULL) {
-        overlay->configured = true;
         enter_first_mode(state);
-    } else if (!overlay->configured) {
+    } else if (!was_configured) {
         // Output not yet known; send a transparent frame to get surface.enter.
         send_transparent_frame_to_overlay(overlay);
     }
-
-    overlay->configured = true;
 }
 
 static void handle_layer_surface_closed(
@@ -706,8 +706,8 @@ static void resolve_result_output(struct state *state) {
         }
     }
 
-    // The result centre is in a dead zone (gap between monitors).  Find the
-    // nearest output and snap the centre to its closest edge.
+    // Result centre is not on any output (e.g. a mode that doesn't yet handle
+    // per-region placement).  Find the nearest output and snap to its edge.
     struct output *best      = NULL;
     int32_t        best_dist = INT32_MAX;
     wl_list_for_each (output, &state->outputs, link) {
@@ -877,7 +877,7 @@ int main(int argc, char **argv) {
     };
 
     int    num_cli_configs      = 0;
-    char **cli_configs          = malloc(10 * sizeof(char *));
+    char **cli_configs          = malloc(10 * sizeof(char*));
     int    cli_configs_len      = 10;
     int    option_char          = 0;
     int    option_index         = 0;
@@ -913,7 +913,7 @@ int main(int argc, char **argv) {
             if (num_cli_configs >= cli_configs_len) {
                 cli_configs_len += 10;
                 cli_configs =
-                    realloc(cli_configs, cli_configs_len * sizeof(char *));
+                    realloc(cli_configs, cli_configs_len * sizeof(char*));
             }
             cli_configs[num_cli_configs++] = optarg;
             break;

--- a/src/main.c
+++ b/src/main.c
@@ -120,6 +120,7 @@ bool compute_initial_area(struct state *state, struct rect *initial_area) {
         struct overlay_surface *overlay;
         wl_list_for_each (overlay, &state->overlay_surfaces, link) {
             struct output *o = overlay->output;
+            if (o == NULL) continue;
             if (o->x < min_x) min_x = o->x;
             if (o->y < min_y) min_y = o->y;
             if (o->x + o->width > max_x) max_x = o->x + o->width;
@@ -932,7 +933,14 @@ int main(int argc, char **argv) {
             break;
 
         case 'A':
-            state.config.general.all_outputs = true;
+            // Push as a cli_config so it is applied after the config file,
+            // giving the CLI flag precedence over any file setting.
+            if (num_cli_configs >= cli_configs_len) {
+                cli_configs_len += 10;
+                cli_configs =
+                    realloc(cli_configs, cli_configs_len * sizeof(char *));
+            }
+            cli_configs[num_cli_configs++] = "all_outputs=true";
             break;
 
         case 'p':

--- a/src/mode_tile.c
+++ b/src/mode_tile.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include <xkbcommon/xkbcommon.h>
 
-#define MIN_SUB_AREA_SIZE   (25 * 50)
+#define MIN_SUB_AREA_SIZE (25 * 50)
 // Upper bound on pending sub-rectangles when computing one output's exclusive
 // area.  In any real monitor layout this will never be reached.
 #define MAX_PENDING_RECTS 64
@@ -22,9 +22,11 @@ static struct rect rect_intersect(struct rect a, struct rect b) {
     int32_t y1 = max(a.y, b.y);
     int32_t x2 = min(a.x + a.w, b.x + b.w);
     int32_t y2 = min(a.y + a.h, b.y + b.h);
-    int32_t w  = x2 - x1;
-    int32_t h  = y2 - y1;
-    return (struct rect){.x = x1, .y = y1, .w = w > 0 ? w : 0, .h = h > 0 ? h : 0};
+    return (struct rect){
+        .x = x1, .y = y1,
+        .w = x2 > x1 ? x2 - x1 : 0,
+        .h = y2 > y1 ? y2 - y1 : 0,
+    };
 }
 
 // Subtract rectangle b from rectangle a using a cross decomposition:
@@ -39,13 +41,13 @@ static int rect_subtract(struct rect a, struct rect b, struct rect out[4]) {
     }
     int n = 0;
     if (i.x > a.x)
-        out[n++] = (struct rect){.x = a.x,       .y = a.y, .w = i.x - a.x,               .h = a.h};
+        out[n++] = (struct rect){.x = a.x, .y = a.y, .w = i.x - a.x, .h = a.h};
     if (i.x + i.w < a.x + a.w)
         out[n++] = (struct rect){.x = i.x + i.w, .y = a.y, .w = (a.x + a.w) - (i.x + i.w), .h = a.h};
     if (i.y > a.y)
-        out[n++] = (struct rect){.x = i.x,        .y = a.y,       .w = i.w, .h = i.y - a.y};
+        out[n++] = (struct rect){.x = i.x, .y = a.y, .w = i.w, .h = i.y - a.y};
     if (i.y + i.h < a.y + a.h)
-        out[n++] = (struct rect){.x = i.x,        .y = i.y + i.h, .w = i.w, .h = (a.y + a.h) - (i.y + i.h)};
+        out[n++] = (struct rect){.x = i.x, .y = i.y + i.h, .w = i.w, .h = (a.y + a.h) - (i.y + i.h)};
     return n;
 }
 

--- a/src/mode_tile.c
+++ b/src/mode_tile.c
@@ -14,11 +14,8 @@
 #define MIN_SUB_AREA_SIZE (25 * 50)
 
 void *tile_mode_enter(struct state *state, struct rect area) {
-    struct tile_mode_state *ms = malloc(sizeof(*ms));
+    struct tile_mode_state *ms = calloc(1, sizeof(*ms));
     ms->area                   = area;
-    ms->regions                = NULL;
-    ms->num_regions            = 0;
-    ms->cell_idx_map           = NULL;
 
     const int max_num_sub_areas = 26 * 26;
 
@@ -203,10 +200,8 @@ static bool tile_mode_key(
                     break;
                 }
             } else {
-                int cell_idx =
-                    ms->cell_idx_map ? ms->cell_idx_map[label_idx] : label_idx;
                 enter_next_mode(
-                    state, idx_to_rect(ms, cell_idx, ms->area.x, ms->area.y)
+                    state, idx_to_rect(ms, label_idx, ms->area.x, ms->area.y)
                 );
             }
         }
@@ -216,9 +211,8 @@ static bool tile_mode_key(
     return false;
 }
 
-// Render one selectable cell at position (x, y) with size (w, h) in the
-// current cairo coordinate space.  curr_label is the label for this cell;
-// ms->label_selection holds the user's current input.
+// Render one selectable cell at position (x, y) with size (w, h).
+// curr_label is the label for this cell; selection is the current user input.
 static void render_cell(
     struct mode_tile_config *config, cairo_t *cairo,
     label_selection_t *curr_label, label_selection_t *selection,
@@ -334,9 +328,8 @@ void tile_mode_render(struct state *state, void *mode_state, cairo_t *cairo) {
         label_selection_set_from_idx(curr_label, 0);
 
         for (int li = 0; li < num_labels; li++) {
-            int ci     = ms->cell_idx_map ? ms->cell_idx_map[li] : li;
-            int column = ci / ms->sub_area_rows;
-            int row    = ci % ms->sub_area_rows;
+            int column = li / ms->sub_area_rows;
+            int row    = li % ms->sub_area_rows;
 
             int x = column * ms->sub_area_width +
                     min(column, ms->sub_area_width_off);
@@ -366,7 +359,6 @@ void tile_mode_state_free(void *mode_state) {
     label_selection_free(ms->label_selection);
     label_symbols_free(ms->label_symbols);
     free(ms->regions);
-    free(ms->cell_idx_map);
     free(ms);
 }
 

--- a/src/mode_tile.c
+++ b/src/mode_tile.c
@@ -358,7 +358,7 @@ void tile_mode_render(struct state *state, void *mode_state, cairo_t *cairo) {
     char label_unselected_str[label_str_max_len];
 
     if (ms->regions != NULL) {
-        // Region-based rendering: iterate over each monitor's region.
+        // Render cells in each exclusive sub-region.
         for (int ri = 0; ri < ms->num_regions; ri++) {
             struct tile_region *r = &ms->regions[ri];
 

--- a/src/screencopy.c
+++ b/src/screencopy.c
@@ -121,7 +121,7 @@ const struct zwlr_screencopy_frame_v1_listener screencopy_frame_listener = {
 };
 
 struct scrcpy_buffer *
-query_screenshot(struct state *state, struct rect region) {
+query_screenshot(struct state *state, struct wl_output *wl_output, struct rect region) {
     struct scrcpy_state scrcpy_state;
     scrcpy_state.wl_shm = state->wl_shm;
 
@@ -137,8 +137,7 @@ query_screenshot(struct state *state, struct rect region) {
     scrcpy_state.wl_screencopy_frame =
         zwlr_screencopy_manager_v1_capture_output_region(
             state->wl_screencopy_manager, false,
-            state->current_output->wl_output, region.x, region.y, region.w,
-            region.h
+            wl_output, region.x, region.y, region.w, region.h
         );
     zwlr_screencopy_frame_v1_add_listener(
         scrcpy_state.wl_screencopy_frame, &screencopy_frame_listener,

--- a/src/screencopy.h
+++ b/src/screencopy.h
@@ -16,7 +16,9 @@ struct scrcpy_buffer {
 
 struct state;
 struct rect;
-struct scrcpy_buffer *query_screenshot(struct state *state, struct rect region);
+struct scrcpy_buffer *query_screenshot(
+    struct state *state, struct wl_output *wl_output, struct rect region
+);
 
 void destroy_scrcpy_buffer(struct scrcpy_buffer *buf);
 

--- a/src/state.h
+++ b/src/state.h
@@ -50,6 +50,10 @@ struct tile_mode_state {
     int sub_area_height;
     int sub_area_height_off;
 
+    // Maps label index -> linear cell index. NULL when every cell is valid
+    // (single-output mode or no dead zones).
+    int *cell_idx_map;
+
     label_selection_t *label_selection;
     label_symbols_t   *label_symbols;
 

--- a/src/state.h
+++ b/src/state.h
@@ -39,7 +39,9 @@
 
 struct mode_interface;
 
-// One selectable region per monitor in all-outputs mode.
+// One exclusive sub-rectangle of an output in all-outputs mode.
+// A single output may produce multiple tile_region structs if its bounds
+// partially overlap with a previously processed output.
 struct tile_region {
     struct rect area;       // position and size in global coordinates
     int         rows;

--- a/src/state.h
+++ b/src/state.h
@@ -66,7 +66,6 @@ struct tile_mode_state {
     int sub_area_columns;
     int sub_area_height;
     int sub_area_height_off;
-    int *cell_idx_map;
 
     label_selection_t *label_selection;
     label_symbols_t   *label_symbols;
@@ -118,12 +117,12 @@ struct state;
 struct overlay_surface {
     struct wl_list link; // type: struct overlay_surface
 
-    struct wl_surface            *wl_surface;
-    struct wl_callback           *wl_surface_callback;
-    struct zwlr_layer_surface_v1 *wl_layer_surface;
-    struct wp_viewport           *wp_viewport;
+    struct wl_surface             *wl_surface;
+    struct wl_callback            *wl_surface_callback;
+    struct zwlr_layer_surface_v1  *wl_layer_surface;
+    struct wp_viewport            *wp_viewport;
     struct wp_fractional_scale_v1 *fractional_scale;
-    struct surface_buffer_pool    surface_buffer_pool;
+    struct surface_buffer_pool     surface_buffer_pool;
 
     uint32_t width;
     uint32_t height;

--- a/src/state.h
+++ b/src/state.h
@@ -39,19 +39,33 @@
 
 struct mode_interface;
 
-struct tile_mode_state {
-    struct rect area;
+// One selectable region per monitor in all-outputs mode.
+struct tile_region {
+    struct rect area;       // position and size in global coordinates
+    int         rows;
+    int         cols;
+    int         cell_w;      // base cell width
+    int         cell_w_off;  // columns that get 1 extra px (remainder distribution)
+    int         cell_h;      // base cell height
+    int         cell_h_off;  // rows that get 1 extra px
+    int         label_offset; // index of first label in this region
+    int         num_labels;   // rows * cols
+};
 
+struct tile_mode_state {
+    // Region-based multi-output fields (set when all_outputs is true).
+    // NULL in single-output mode.
+    struct tile_region *regions;
+    int                 num_regions;
+
+    // Single-output fields (used when regions == NULL).
+    struct rect area;
     int sub_area_rows;
     int sub_area_width;
     int sub_area_width_off;
-
     int sub_area_columns;
     int sub_area_height;
     int sub_area_height_off;
-
-    // Maps label index -> linear cell index. NULL when every cell is valid
-    // (single-output mode or no dead zones).
     int *cell_idx_map;
 
     label_selection_t *label_selection;


### PR DESCRIPTION
Alternate implementation of multi-output support for #78, replacing #79.

Following your feedback on #79, this drops the dead-zone approach. Instead, each output is modeled as a **non-overlapping region**: an output's exclusive pixels are its logical bounds minus any area already claimed by a previously-processed output. There are no dead zones. Every label maps to a real, clickable cell, and grids line up with the monitor edges.

### What's included
- `--all-outputs` / `-A` flag (and `all_outputs=true` in `[general]`) to show the overlay across every output simultaneously.
- **Tile mode**: one grid per region. Cell density is derived from the average monitor area so each display keeps roughly its single-output density; labels are indexed continuously across all regions.
- **Floating mode**: all-outputs support too. Detect mode captures each output independently and shifts results to global coordinates; stdin areas are treated as global.
- CLI `-A` precedence fix and a NULL-deref fix in `compute_initial_area`.

### Overlap handling
Exclusive-region subtraction covers corner overlap, landscape+portrait mixes, and full mirror (a fully-mirrored output has no exclusive area and so receives no labels — only the background tint).

### Not included / open questions
- `bisect` and `split` modes still operate on a single region. Per your note that those should "choose the output first, then continue as normal," likely we should add an explicit output-selection step as a follow-up rather than expanding the scope of this PR.
