### PR TITLE
Print documentation in default config

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -323,34 +323,36 @@ struct field_def {
 
 struct section_def {
     char              *name;
+    char              *desc;
     size_t             offset;
     struct field_def **fields;
 };
 
-#define SECTION(name, ...)                                             \
+#define SECTION(name, desc, ...)                                       \
     (struct section_def) {                                             \
-        #name, offsetof(struct config, name), (struct field_def *[]) { \
+        #name, desc,                                                   \
+        offsetof(struct config, name), (struct field_def *[]) {        \
             __VA_ARGS__, NULL                                          \
         }                                                              \
     }
 
-#define FIELD(type, name, default_value, parse, free)           \
-    (struct field_def[]) {                                      \
-        #name, offsetof(type, name), default_value, parse, free, "TODO" \
+#define FIELD(type, name, default_value, parse, free, desc)            \
+    (struct field_def[]) {                                             \
+        #name, offsetof(type, name), default_value, parse, free, desc  \
     }
 
-#define G_FIELD(name, default_value, parse, free) \
-    FIELD(struct general_config, name, default_value, parse, free)
-#define MT_FIELD(name, default_value, parse, free) \
-    FIELD(struct mode_tile_config, name, default_value, parse, free)
-#define MF_FIELD(name, default_value, parse, free) \
-    FIELD(struct mode_floating_config, name, default_value, parse, free)
-#define MB_FIELD(name, default_value, parse, free) \
-    FIELD(struct mode_bisect_config, name, default_value, parse, free)
-#define MS_FIELD(name, default_value, parse, free) \
-    FIELD(struct mode_split_config, name, default_value, parse, free)
-#define MC_FIELD(name, default_value, parse, free) \
-    FIELD(struct mode_click_config, name, default_value, parse, free)
+#define G_FIELD(name, default_value, parse, free, desc) \
+    FIELD(struct general_config, name, default_value, parse, free, desc)
+#define MT_FIELD(name, default_value, parse, free, desc) \
+    FIELD(struct mode_tile_config, name, default_value, parse, free, desc)
+#define MF_FIELD(name, default_value, parse, free, desc) \
+    FIELD(struct mode_floating_config, name, default_value, parse, free, desc)
+#define MB_FIELD(name, default_value, parse, free, desc) \
+    FIELD(struct mode_bisect_config, name, default_value, parse, free, desc)
+#define MS_FIELD(name, default_value, parse, free, desc) \
+    FIELD(struct mode_split_config, name, default_value, parse, free, desc)
+#define MC_FIELD(name, default_value, parse, free, desc) \
+    FIELD(struct mode_click_config, name, default_value, parse, free, desc)
 
 static void noop() {}
 
@@ -359,61 +361,189 @@ static void noop() {}
 static struct section_def section_defs[] = {
     SECTION(
         general,
-        G_FIELD(home_row_keys, "", parse_home_row_keys, free_home_row_keys),
-        G_FIELD(modes, "tile,bisect", parse_str, free_str),
-        G_FIELD(cancellation_status_code, "0", parse_uint8, noop)
+        "General configuration",
+        G_FIELD(
+            home_row_keys, "", parse_home_row_keys, free_home_row_keys,
+            "Home row keys"
+        ),
+        G_FIELD(
+            modes, "tile,bisect", parse_str, free_str,
+            "Modes to use"
+        ),
+        G_FIELD(
+            cancellation_status_code, "0", parse_uint8, noop,
+            "Status code to exit with when cancelled"
+        )
     ),
     SECTION(
-        mode_tile, MT_FIELD(label_color, "#fffd", parse_color, noop),
-        MT_FIELD(label_select_color, "#fd0d", parse_color, noop),
-        MT_FIELD(unselectable_bg_color, "#2226", parse_color, noop),
-        MT_FIELD(selectable_bg_color, "#0304", parse_color, noop),
-        MT_FIELD(selectable_border_color, "#040c", parse_color, noop),
-        MT_FIELD(label_font_family, "sans-serif", parse_str, free_str),
-        MT_FIELD(label_font_size, "8 50% 100", parse_relative_font_size, noop),
+        mode_tile,
+        "Configuration for tile mode",
         MT_FIELD(
-            label_symbols, "abcdefghijklmnopqrstuvwxyz", parse_str, free_str
+            label_color, "#fffd", parse_color, noop,
+            "Label color"
+        ),
+        MT_FIELD(
+            label_select_color, "#fd0d", parse_color, noop,
+            "Selected label color"
+        ),
+        MT_FIELD(
+            unselectable_bg_color, "#2226", parse_color, noop,
+            "Background color for unselectable"
+        ),
+        MT_FIELD(
+            selectable_bg_color, "#0304", parse_color, noop,
+            "Background color for selectable"
+        ),
+        MT_FIELD(
+            selectable_border_color, "#040c", parse_color, noop,
+            "Border color for selectable"
+        ),
+        MT_FIELD(
+            label_font_family, "sans-serif", parse_str, free_str,
+            "Font family for label"
+        ),
+        MT_FIELD(
+            label_font_size, "8 50% 100", parse_relative_font_size, noop,
+            "Font size for label"
+        ),
+        MT_FIELD(
+            label_symbols, "abcdefghijklmnopqrstuvwxyz", parse_str, free_str,
+            "Symbols to use for labels"
         )
     ),
     SECTION(
         mode_floating,
-        MF_FIELD(source, "stdin", parse_floating_mode_source_value, noop),
-        MF_FIELD(label_color, "#fffd", parse_color, noop),
-        MF_FIELD(label_select_color, "#fd0d", parse_color, noop),
-        MF_FIELD(unselectable_bg_color, "#2226", parse_color, noop),
-        MF_FIELD(selectable_bg_color, "#1718", parse_color, noop),
-        MF_FIELD(selectable_border_color, "#040c", parse_color, noop),
-        MF_FIELD(label_font_family, "sans-serif", parse_str, free_str),
-        MF_FIELD(label_font_size, "12 50% 100", parse_relative_font_size, noop),
+        "Configuration for floating mode",
         MF_FIELD(
-            label_symbols, "abcdefghijklmnopqrstuvwxyz", parse_str, free_str
+            source, "stdin", parse_floating_mode_source_value, noop,
+            "Source"
+        ),
+        MF_FIELD(
+            label_color, "#fffd", parse_color, noop,
+            "Color of labels"
+        ),
+        MF_FIELD(
+            label_select_color, "#fd0d", parse_color, noop,
+            "Selected label color"
+        ),
+        MF_FIELD(
+            unselectable_bg_color, "#2226", parse_color, noop,
+            "Background color of unselectable"
+        ),
+        MF_FIELD(
+            selectable_bg_color, "#1718", parse_color, noop,
+            "Background color of selectable"
+        ),
+        MF_FIELD(
+            selectable_border_color, "#040c", parse_color, noop,
+            "Border color of selectable"
+        ),
+        MF_FIELD(
+            label_font_family, "sans-serif", parse_str, free_str,
+            "Font family for label"
+        ),
+        MF_FIELD(
+            label_font_size, "12 50% 100", parse_relative_font_size, noop,
+            "Font size for label"
+        ),
+        MF_FIELD(
+            label_symbols, "abcdefghijklmnopqrstuvwxyz", parse_str, free_str,
+            "Symbols to use for labels"
         )
     ),
     SECTION(
-        mode_bisect, MB_FIELD(label_color, "#fffd", parse_color, noop),
+        mode_bisect,
+        "Configuration for bisect mode",
+        MB_FIELD(
+            label_color, "#fffd", parse_color, noop,
+            "Label color"
+        ),
         // TODO: we should set minimums for numbers.
-        MB_FIELD(label_font_size, "20", parse_double, noop),
-        MB_FIELD(label_font_family, "sans-serif", parse_str, free_str),
-        MB_FIELD(label_padding, "12", parse_double, noop),
-        MB_FIELD(pointer_size, "20", parse_double, noop),
-        MB_FIELD(pointer_color, "#e22d", parse_color, noop),
-        MB_FIELD(unselectable_bg_color, "#2226", parse_color, noop),
-        MB_FIELD(even_area_bg_color, "#0304", parse_color, noop),
-        MB_FIELD(even_area_border_color, "#0408", parse_color, noop),
-        MB_FIELD(odd_area_bg_color, "#0034", parse_color, noop),
-        MB_FIELD(odd_area_border_color, "#0048", parse_color, noop),
-        MB_FIELD(history_border_color, "#3339", parse_color, noop)
+        MB_FIELD(
+            label_font_size, "20", parse_double, noop,
+            "Font size for labels"
+        ),
+        MB_FIELD(
+            label_font_family, "sans-serif", parse_str, free_str,
+            "Font family for labels"
+        ),
+        MB_FIELD(
+            label_padding, "12", parse_double, noop,
+            "Padding for labels"
+        ),
+        MB_FIELD(
+            pointer_size, "20", parse_double, noop,
+            "Pointer size"
+        ),
+        MB_FIELD(
+            pointer_color, "#e22d", parse_color, noop,
+            "Pointer color"
+        ),
+        MB_FIELD(
+            unselectable_bg_color, "#2226", parse_color, noop,
+            "Background color for unselectable"
+        ),
+        MB_FIELD(
+            even_area_bg_color, "#0304", parse_color, noop,
+            "Background color for even area"
+        ),
+        MB_FIELD(
+            even_area_border_color, "#0408", parse_color, noop,
+            "Border color for even area"
+        ),
+        MB_FIELD(
+            odd_area_bg_color, "#0034", parse_color, noop,
+            "Background color for odd area"
+        ),
+        MB_FIELD(
+            odd_area_border_color, "#0048", parse_color, noop,
+            "Border color for odd area"
+        ),
+        MB_FIELD(
+            history_border_color, "#3339", parse_color, noop,
+            "Border color for history"
+        )
     ),
     SECTION(
-        mode_split, MS_FIELD(pointer_size, "20", parse_double, noop),
-        MS_FIELD(pointer_color, "#e22d", parse_color, noop),
-        MS_FIELD(bg_color, "#2226", parse_color, noop),
-        MS_FIELD(area_bg_color, "#11111188", parse_color, noop),
-        MS_FIELD(vertical_color, "#8888ffcc", parse_color, noop),
-        MS_FIELD(horizontal_color, "#008800cc", parse_color, noop),
-        MS_FIELD(history_border_color, "#3339", parse_color, noop)
+        mode_split,
+        "Configuration for split mode",
+        MS_FIELD(
+            pointer_size, "20", parse_double, noop,
+            "Pointer size"
+        ),
+        MS_FIELD(
+            pointer_color, "#e22d", parse_color, noop,
+            "Pointer color"
+        ),
+        MS_FIELD(
+            bg_color, "#2226", parse_color, noop,
+            "Background color"
+        ),
+        MS_FIELD(
+            area_bg_color, "#11111188", parse_color, noop,
+            "Background color for area"
+        ),
+        MS_FIELD(
+            vertical_color, "#8888ffcc", parse_color, noop,
+            "Color for vertical marker"
+        ),
+        MS_FIELD(
+            horizontal_color, "#008800cc", parse_color, noop,
+            "Color for horizontal marker"
+        ),
+        MS_FIELD(
+            history_border_color, "#3339", parse_color, noop,
+            "Border color for history"
+        )
     ),
-    SECTION(mode_click, MC_FIELD(button, "left", parse_click, noop)),
+    SECTION(
+        mode_click,
+        "Configuration for click mode",
+        MC_FIELD(
+            button, "left", parse_click, noop,
+            "Mouse button"
+        )
+    ),
 };
 #pragma GCC diagnostic pop
 
@@ -426,7 +556,7 @@ void print_default_config() {
     for (int i = 0; i < sizeof(section_defs) / sizeof(section_defs[0]); i++) {
         struct section_def *section_def = &section_defs[i];
 
-        printf("\n[%s]\n", section_def->name);
+        printf("\n[%s]\n## %s ##\n", section_def->name, section_def->desc);
 
         for (struct field_def **field_def_ptr = section_def->fields;
              *field_def_ptr != NULL; field_def_ptr++) {

--- a/src/config.c
+++ b/src/config.c
@@ -318,6 +318,7 @@ struct field_def {
     char  *default_value;
     int (*parse)(void *dest, char *value);
     void (*free)(void *value);
+    char *desc;
 };
 
 struct section_def {
@@ -335,7 +336,7 @@ struct section_def {
 
 #define FIELD(type, name, default_value, parse, free)           \
     (struct field_def[]) {                                      \
-        #name, offsetof(type, name), default_value, parse, free \
+        #name, offsetof(type, name), default_value, parse, free, "TODO" \
     }
 
 #define G_FIELD(name, default_value, parse, free) \
@@ -431,7 +432,10 @@ void print_default_config() {
              *field_def_ptr != NULL; field_def_ptr++) {
             struct field_def *field_def = *field_def_ptr;
 
-            printf("%s=%s\n", field_def->name, field_def->default_value);
+            printf(
+                "# %s\n%s=%s\n\n",
+                field_def->desc, field_def->name, field_def->default_value
+            );
         }
     }
 }

--- a/src/config.c
+++ b/src/config.c
@@ -416,39 +416,41 @@ static struct section_def section_defs[] = {
         "Configuration for floating mode",
         MF_FIELD(
             source, "stdin", parse_floating_mode_source_value, noop,
-            "Source"
+            "Source of selectable regions. Possible values:\n"
+            "* `detect` -- auto-detect regions with OpenCV\n"
+            "* `stdin` -- read region definitions from stdin"
         ),
         MF_FIELD(
             label_color, "#fffd", parse_color, noop,
-            "Color of labels"
+            "Label color for selectable regions"
         ),
         MF_FIELD(
             label_select_color, "#fd0d", parse_color, noop,
-            "Selected label color"
+            "Label color for selected regions"
         ),
         MF_FIELD(
             unselectable_bg_color, "#2226", parse_color, noop,
-            "Background color of unselectable"
+            "Background color for unselectable regions"
         ),
         MF_FIELD(
             selectable_bg_color, "#1718", parse_color, noop,
-            "Background color of selectable"
+            "Background color for selectable regions"
         ),
         MF_FIELD(
             selectable_border_color, "#040c", parse_color, noop,
-            "Border color of selectable"
+            "Border color for selectable regions"
         ),
         MF_FIELD(
             label_font_family, "sans-serif", parse_str, free_str,
-            "Font family for label"
+            "Font family for labels"
         ),
         MF_FIELD(
             label_font_size, "12 50% 100", parse_relative_font_size, noop,
-            "Font size for label"
+            "Font size for labels"
         ),
         MF_FIELD(
             label_symbols, "abcdefghijklmnopqrstuvwxyz", parse_str, free_str,
-            "Symbols to use for labels"
+            "Characters to use in labels"
         )
     ),
     SECTION(

--- a/src/config.c
+++ b/src/config.c
@@ -505,7 +505,7 @@ static struct section_def section_defs[] = {
         ),
         MB_FIELD(
             history_border_color, "#3339", parse_color, noop,
-            "Border color for previously selected regions"
+            "Border color for selection hisory"
         )
     ),
     SECTION(
@@ -520,24 +520,26 @@ static struct section_def section_defs[] = {
             "Pointer color"
         ),
         MS_FIELD(
+            // TODO[glowingscrewdriver] why is this not named
+            // `unselectable_bg_color`?
             bg_color, "#2226", parse_color, noop,
-            "Background color"
+            "Background color for unselectable area"
         ),
         MS_FIELD(
             area_bg_color, "#11111188", parse_color, noop,
-            "Background color for area"
+            "Background color for selectable area"
         ),
         MS_FIELD(
             vertical_color, "#8888ffcc", parse_color, noop,
-            "Color for vertical marker"
+            "Color for vertical split marker"
         ),
         MS_FIELD(
             horizontal_color, "#008800cc", parse_color, noop,
-            "Color for horizontal marker"
+            "Color for horizontal split marker"
         ),
         MS_FIELD(
             history_border_color, "#3339", parse_color, noop,
-            "Border color for history"
+            "Border color for selection history"
         )
     ),
     SECTION(
@@ -545,7 +547,7 @@ static struct section_def section_defs[] = {
         "Configuration for click mode",
         MC_FIELD(
             button, "left", parse_click, noop,
-            "Mouse button"
+            "Mouse button to trigger"
         )
     ),
 };

--- a/src/config.c
+++ b/src/config.c
@@ -562,7 +562,7 @@ void print_default_config() {
     for (int i = 0; i < sizeof(section_defs) / sizeof(section_defs[0]); i++) {
         struct section_def *section_def = &section_defs[i];
 
-        printf("\n[%s]\n## %s ##\n", section_def->name, section_def->desc);
+        printf("\n## %s ##\n[%s]\n", section_def->desc, section_def->name);
 
         for (struct field_def **field_def_ptr = section_def->fields;
              *field_def_ptr != NULL; field_def_ptr++) {

--- a/src/config.c
+++ b/src/config.c
@@ -454,11 +454,12 @@ static struct section_def section_defs[] = {
         )
     ),
     SECTION(
+        // TODO[glowingscewdriver]: Explain "even" and "odd" areas
         mode_bisect,
         "Configuration for bisect mode",
         MB_FIELD(
             label_color, "#fffd", parse_color, noop,
-            "Label color"
+            "Label color for selectable regions"
         ),
         // TODO: we should set minimums for numbers.
         MB_FIELD(
@@ -470,6 +471,7 @@ static struct section_def section_defs[] = {
             "Font family for labels"
         ),
         MB_FIELD(
+            // TODO[glowingscrewdriver]: What does this actually do?
             label_padding, "12", parse_double, noop,
             "Padding for labels"
         ),
@@ -483,27 +485,27 @@ static struct section_def section_defs[] = {
         ),
         MB_FIELD(
             unselectable_bg_color, "#2226", parse_color, noop,
-            "Background color for unselectable"
+            "Background color for unselectable regions"
         ),
         MB_FIELD(
             even_area_bg_color, "#0304", parse_color, noop,
-            "Background color for even area"
+            "Background color for even areas"
         ),
         MB_FIELD(
             even_area_border_color, "#0408", parse_color, noop,
-            "Border color for even area"
+            "Border color for even areas"
         ),
         MB_FIELD(
             odd_area_bg_color, "#0034", parse_color, noop,
-            "Background color for odd area"
+            "Background color for odd areas"
         ),
         MB_FIELD(
             odd_area_border_color, "#0048", parse_color, noop,
-            "Border color for odd area"
+            "Border color for odd areas"
         ),
         MB_FIELD(
             history_border_color, "#3339", parse_color, noop,
-            "Border color for history"
+            "Border color for previously selected regions"
         )
     ),
     SECTION(

--- a/src/config.c
+++ b/src/config.c
@@ -368,7 +368,7 @@ static struct section_def section_defs[] = {
         ),
         G_FIELD(
             modes, "tile,bisect", parse_str, free_str,
-            "Modes to use"
+            "Modes to use; will be chained"
         ),
         G_FIELD(
             cancellation_status_code, "0", parse_uint8, noop,
@@ -380,35 +380,35 @@ static struct section_def section_defs[] = {
         "Configuration for tile mode",
         MT_FIELD(
             label_color, "#fffd", parse_color, noop,
-            "Label color"
+            "Label color for selectable regions"
         ),
         MT_FIELD(
             label_select_color, "#fd0d", parse_color, noop,
-            "Selected label color"
+            "Label color for selected regions"
         ),
         MT_FIELD(
             unselectable_bg_color, "#2226", parse_color, noop,
-            "Background color for unselectable"
+            "Background color for unselectable regions"
         ),
         MT_FIELD(
             selectable_bg_color, "#0304", parse_color, noop,
-            "Background color for selectable"
+            "Background color for selectable regions"
         ),
         MT_FIELD(
             selectable_border_color, "#040c", parse_color, noop,
-            "Border color for selectable"
+            "Border color for selectable regions"
         ),
         MT_FIELD(
             label_font_family, "sans-serif", parse_str, free_str,
-            "Font family for label"
+            "Font family for labels"
         ),
         MT_FIELD(
             label_font_size, "8 50% 100", parse_relative_font_size, noop,
-            "Font size for label"
+            "Font size for labels"
         ),
         MT_FIELD(
             label_symbols, "abcdefghijklmnopqrstuvwxyz", parse_str, free_str,
-            "Symbols to use for labels"
+            "Characters to use in labels"
         )
     ),
     SECTION(

--- a/src/config.c
+++ b/src/config.c
@@ -553,11 +553,24 @@ static struct section_def section_defs[] = {
 };
 #pragma GCC diagnostic pop
 
+void print_comment (char * comment) {
+    // Print a multi-line string as a comment.
+    printf ("# ");
+    for (char *c = comment; *c != '\0'; c++) {
+        putchar (*c);
+        if (*c == '\n')
+            printf ("# ");
+    }
+    putchar ('\n');
+}
+
 void print_default_config() {
-    puts("# wl-kbptr can be configured with a configuration file.");
-    puts("# The file location can be passed with the -c parameter.");
-    puts("# Othewise the `$XDG_CONFIG_HOME/wl-kbptr/config` file will");
-    puts("# be loaded if it exits. Below is the default configuration.");
+    print_comment (
+        "wl-kbptr can be configured with a configuration file.\n"
+        "The file location can be passed with the -c parameter.\n"
+        "Othewise the `$XDG_CONFIG_HOME/wl-kbptr/config` file will\n"
+        "be loaded if it exits. Below is the default configuration."
+    );
 
     for (int i = 0; i < sizeof(section_defs) / sizeof(section_defs[0]); i++) {
         struct section_def *section_def = &section_defs[i];
@@ -568,9 +581,10 @@ void print_default_config() {
              *field_def_ptr != NULL; field_def_ptr++) {
             struct field_def *field_def = *field_def_ptr;
 
+            print_comment (field_def->desc);
             printf(
-                "# %s\n%s=%s\n\n",
-                field_def->desc, field_def->name, field_def->default_value
+                "%s=%s\n\n",
+                field_def->name, field_def->default_value
             );
         }
     }

--- a/src/config.c
+++ b/src/config.c
@@ -406,7 +406,9 @@ static struct section_def section_defs[] = {
         ),
         MT_FIELD(
             label_font_size, "8 50% 100", parse_relative_font_size, noop,
-            "Font size for labels"
+            "Font size for labels, specified as `<min> <pct>% <max>`.\n"
+            "The resulting font size is a percentage of the region height\n"
+            "(specified by <pct>), bounded by <min> and <max>."
         ),
         MT_FIELD(
             label_symbols, "abcdefghijklmnopqrstuvwxyz", parse_str, free_str,
@@ -448,7 +450,8 @@ static struct section_def section_defs[] = {
         ),
         MF_FIELD(
             label_font_size, "12 50% 100", parse_relative_font_size, noop,
-            "Font size for labels"
+            "Font size for labels.\n"
+            "See mode_tile.label_font_size for a detailed description."
         ),
         MF_FIELD(
             label_symbols, "abcdefghijklmnopqrstuvwxyz", parse_str, free_str,
@@ -465,7 +468,7 @@ static struct section_def section_defs[] = {
         // TODO: we should set minimums for numbers.
         MB_FIELD(
             label_font_size, "20", parse_double, noop,
-            "Font size for labels"
+            "Font size for labels. Note that a lower bound is applied internally."
         ),
         MB_FIELD(
             label_font_family, "sans-serif", parse_str, free_str,

--- a/src/config.c
+++ b/src/config.c
@@ -364,11 +364,13 @@ static struct section_def section_defs[] = {
         "General configuration",
         G_FIELD(
             home_row_keys, "", parse_home_row_keys, free_home_row_keys,
-            "Home row keys"
+            "A string of exactly 11 characters, each representing a key.\n"
+            "The first 8 will be used to select sub-areas in bisect mode.\n"
+            "The last 3 will be used as left, right and middle click respectively."
         ),
         G_FIELD(
             modes, "tile,bisect", parse_str, free_str,
-            "Modes to use; will be chained"
+            "Modes (tile, bisect, split or float) to use; will be chained."
         ),
         G_FIELD(
             cancellation_status_code, "0", parse_uint8, noop,
@@ -454,7 +456,6 @@ static struct section_def section_defs[] = {
         )
     ),
     SECTION(
-        // TODO[glowingscewdriver]: Explain "even" and "odd" areas
         mode_bisect,
         "Configuration for bisect mode",
         MB_FIELD(
@@ -471,9 +472,9 @@ static struct section_def section_defs[] = {
             "Font family for labels"
         ),
         MB_FIELD(
-            // TODO[glowingscrewdriver]: What does this actually do?
             label_padding, "12", parse_double, noop,
-            "Padding for labels"
+            "Spacing between a selectable region and its label.\n"
+            "Applicable when the region is smaller than the label."
         ),
         MB_FIELD(
             pointer_size, "20", parse_double, noop,
@@ -489,19 +490,21 @@ static struct section_def section_defs[] = {
         ),
         MB_FIELD(
             even_area_bg_color, "#0304", parse_color, noop,
-            "Background color for even areas"
+            "Background color for even areas.\n"
+            "Odd/even areas are selectable areas with odd/even indices,\n"
+            "when counting row-wise (or column-wise), starting from 0."
         ),
         MB_FIELD(
             even_area_border_color, "#0408", parse_color, noop,
-            "Border color for even areas"
+            "Border color for even areas (see `even_area_bg_color`)"
         ),
         MB_FIELD(
             odd_area_bg_color, "#0034", parse_color, noop,
-            "Background color for odd areas"
+            "Background color for odd areas (see `even_area_bg_color`)"
         ),
         MB_FIELD(
             odd_area_border_color, "#0048", parse_color, noop,
-            "Border color for odd areas"
+            "Border color for odd areas (see `even_area_bg_color`)"
         ),
         MB_FIELD(
             history_border_color, "#3339", parse_color, noop,
@@ -520,8 +523,6 @@ static struct section_def section_defs[] = {
             "Pointer color"
         ),
         MS_FIELD(
-            // TODO[glowingscrewdriver] why is this not named
-            // `unselectable_bg_color`?
             bg_color, "#2226", parse_color, noop,
             "Background color for unselectable area"
         ),


### PR DESCRIPTION
This change causes `wl-kbptr --help-config` to print comments containing descriptions for all fields and sections in the default config. Since `--help-config` prints an exhaustive list of all config fields and sections, what is printed is effectively full documentation on configuration.

May fix #50 