### PR TITLE
Support building against OpenCV 4 or 5

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,7 +26,7 @@ cc = meson.get_compiler('c')
 if use_opencv
   add_project_arguments('-DOPENCV_ENABLED=1', language: ['c', 'cpp'])
   add_languages('cpp', native: false)
-  opencv = dependency('opencv4')
+  opencv = dependency('opencv4', 'opencv5')
   pixman = dependency('pixman-1')
 endif
 

--- a/src/target_detection.cpp
+++ b/src/target_detection.cpp
@@ -6,6 +6,10 @@
 
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/imgproc.hpp>
+// OpenCV 5 moved `cv::boundingRect` out of `imgproc.hpp`.
+#if __has_include(<opencv2/geometry/2d.hpp>)
+#include <opencv2/geometry/2d.hpp>
+#endif
 #include <pixman.h>
 #include <stdint.h>
 #include <stdlib.h>


### PR DESCRIPTION
Fixes #99.

Arch switched to OpenCV 5 and `wl-kbptr` stopped building there with
`-Dopencv=enabled`. OpenCV 5 moved `cv::boundingRect` out of `imgproc.hpp`
into `opencv2/geometry/2d.hpp`, so the build fails first on the missing
`opencv4` pkg-config file, and then on `'boundingRect' is not a member of
'cv'` once you point it at OpenCV 5.

I saw the patch in #99, but it swaps `opencv4` for `opencv5` outright, and
Debian, Ubuntu and Fedora are all still on OpenCV 4. So this looks for
OpenCV 4 first and only falls back to 5, with the moved header guarded by
`__has_include`. If your build works today, nothing changes for you: same
dependency, and the new include gets skipped entirely.

I tested both sides. On my Arch machine (OpenCV 5.0.0, no opencv4 installed
at all) it resolves opencv5 and builds. In a Debian trixie container
(OpenCV 4.10, no opencv5) it resolves opencv4 and builds. Release build with
`-Dopencv=enabled` both times, `test_label` passes, and clang-format is happy.

I also wanted to check that OpenCV 5 wasn't just linking but actually
detecting the same things, so I called `compute_target_from_img_buffer()` on a
synthetic image with four rectangles in known positions. It returned all
four, each a couple of pixels bigger than what I drew, which is what the
dilate kernel should do.

One thing I haven't done is run `mode_floating.source=detect` against a real
screen on OpenCV 5. The change doesn't touch the screencopy path so I don't
expect trouble, but I didn't want to claim more than I actually checked.

Minor thing in case it comes up: OpenCV 5 moves `boundingRect` into a separate
`libopencv_geometry`, but `pkg-config --libs opencv5` already lists it, so
there's nothing to change on the link line.
