### PR TITLE
fix: correct exists typo in default config

### DIFF
--- a/config.example
+++ b/config.example
@@ -1,7 +1,7 @@
 # wl-kbptr can be configured with a configuration file.
 # The file location can be passed with the -c parameter.
 # Othewise the `$XDG_CONFIG_HOME/wl-kbptr/config` file will
-# be loaded if it exits. Below is the default configuration.
+# be loaded if it exists. Below is the default configuration.
 
 [general]
 home_row_keys=

--- a/src/config.c
+++ b/src/config.c
@@ -422,7 +422,7 @@ void print_default_config() {
     puts("# wl-kbptr can be configured with a configuration file.");
     puts("# The file location can be passed with the -c parameter.");
     puts("# Othewise the `$XDG_CONFIG_HOME/wl-kbptr/config` file will");
-    puts("# be loaded if it exits. Below is the default configuration.");
+    puts("# be loaded if it exists. Below is the default configuration.");
 
     for (int i = 0; i < sizeof(section_defs) / sizeof(section_defs[0]); i++) {
         struct section_def *section_def = &section_defs[i];


### PR DESCRIPTION
## Summary
Fixes the typo reported in #100: default configuration used `exits` instead of `exists` in `src/config.c` and `config.example`.

## Test plan
- [ ] Confirm wording in default/example config reads `exists`
- [ ] No behavior change beyond comment/string text